### PR TITLE
feat: Extend support for Golang in Component Analysis.

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/analytics/Platform.java
+++ b/src/main/java/org/jboss/tools/intellij/analytics/Platform.java
@@ -4,6 +4,9 @@ import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.util.SystemInfo;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class Platform {
   //Set Plugin location in host machine. Location will be used as download location.
   public static final String pluginDirectory = PluginManagerCore.getPlugin(
@@ -32,4 +35,8 @@ public class Platform {
   }
 
   public static final Platform current = detect();
+
+  // Set supported file names
+  public static final List<String> supportedManifestFiles = Arrays.asList("pom.xml",
+          "package.json", "go.mod", "requirements.txt", "requirements-dev.txt");
 }

--- a/src/main/java/org/jboss/tools/intellij/analytics/PreloadLanguageServer.java
+++ b/src/main/java/org/jboss/tools/intellij/analytics/PreloadLanguageServer.java
@@ -2,6 +2,7 @@ package org.jboss.tools.intellij.analytics;
 
 import java.io.File;
 import java.io.IOException;
+
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PreloadingActivity;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -14,14 +15,13 @@ public final class PreloadLanguageServer extends PreloadingActivity {
   private final ICookie cookies = ServiceManager.getService(Settings.class);
 
   private void attachLanguageClient(final File cliFile) {
-    final String[] EXTENSIONS = {"xml", "json", "txt"};
     final String[] cmds = {cliFile.toString(), "--stdio"};
     ApplicationManager.getApplication().invokeAndWait(() -> {
-      for (String ext : EXTENSIONS) {
+      Platform.supportedManifestFiles.stream().map(s -> s.substring(s.lastIndexOf('.') + 1)).distinct().forEach(ext -> {
         AnalyticsLanguageServerDefinition serverDefinition = new AnalyticsLanguageServerDefinition(ext, cmds);
         IntellijLanguageClient.addServerDefinition(serverDefinition);
-        IntellijLanguageClient.addExtensionManager(ext, serverDefinition);
-      }
+        IntellijLanguageClient.addExtensionManager(ext, serverDefinition);}
+      );
     });
     log.warn(String.format("lsp registration done %s", cliFile));
   }

--- a/src/main/java/org/jboss/tools/intellij/stackanalysis/SaAction.java
+++ b/src/main/java/org/jboss/tools/intellij/stackanalysis/SaAction.java
@@ -21,9 +21,8 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 
+import org.jboss.tools.intellij.analytics.Platform;
 import org.jetbrains.annotations.NotNull;
-import java.util.Arrays;
-import java.util.List;
 
 
 public class SaAction extends AnAction {
@@ -69,16 +68,12 @@ public class SaAction extends AnAction {
      */
     @Override
     public void update(AnActionEvent event) {
-        // Set supported file names
-        List<String> supportedManifestFiles = Arrays.asList("pom.xml", "package.json",
-                "requirements.txt", "requirements-dev.txt", "go.mod");
-
         PsiFile psiFile = event.getData(CommonDataKeys.PSI_FILE);
 
         // Check if file where context menu is opened is type of supported extension.
         // If yes then show the action for SA in menu
         if (psiFile != null) {
-            event.getPresentation().setEnabledAndVisible(supportedManifestFiles
+            event.getPresentation().setEnabledAndVisible(Platform.supportedManifestFiles
                     .contains(psiFile.getName()));
         } else {
             event.getPresentation().setEnabledAndVisible(false);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,7 +43,7 @@
       <h2>Quick Start</h2>
       <ul>
         <li>Install the extension.</li>
-        <li>Opening or editing a manifest file (<code>pom.xml</code> / <code>package.json</code> / <code>requirements.txt</code>) scans your application for security vulnerabilities.</li>
+        <li>Opening or editing a manifest file (<code>pom.xml</code> / <code>package.json</code> / <code>requirements.txt</code> / <code>go.mod</code>) scans your application for security vulnerabilities.</li>
         <li>Opening or editing a manifest file (pom.xml / package.json / requirements.txt / go.mod) scans your application for security vulnerabilities.</li>
         <li>Click on icon from 'Navigation bar' or right click on a manifest file (pom.xml/package.json / requirements.txt / go.mod) in the 'File explorer' or 'File editor' to display 'Dependency Analytics Report' for your application.</li>
       </ul>


### PR DESCRIPTION
# Description
Current version of Dependency Analytics IJ Plugin does not support Golang for Component Analysis, as Golang is now supported by CRDA extension we just need to add .mod in allowed extensions rest will be taken case by LSP and CRDA.   

Signed-off-by: jparsai <jparsai@redhat.com>