### PR TITLE
ci: remove older unsupported version for ci matrix

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IC-2020.1, IC-2020.2, IC-2020.3, IC-2021.1, IC-2021.2, IC-2021.3, IC-2022.1, IC-2022.2, IC-2022.3]
+        IJ: [IC-2021.1, IC-2021.2, IC-2021.3, IC-2022.1, IC-2022.2, IC-2022.3]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Our minimum target version is 2021.1 since https://github.com/redhat-developer/intellij-dependency-analytics/commit/4b67bd4437ad9f12bb913d1ba76b951dd220a4f7.
Based on [this doc](https://docs.google.com/document/d/1dBq4bVlg_r0D7Fp_xu57JepixE2EseNP9hE-Es7fMz8/edit), looks like there was a reason for setting this.
We don't need to test the build process for older versions.
