### PR TITLE
build: bump java version from 1.8 to 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'java'
 apply plugin: 'jacoco'
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '11'
+targetCompatibility = '11'
 
 intellij {
     version = ideaVersion //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases


### PR DESCRIPTION
We target IntelliJ version to major 2021.1 which have been migrated to java 11.
[Supporting article](https://blog.jetbrains.com/platform/2020/09/intellij-project-migrates-to-java-11/?_ga=2.166000830.1812486158.1678029361-235557010.1676467140&_gac=1.24742216.1677670379.CjwKCAiAjPyfBhBMEiwAB2CCIrNHLddgPF1Gc8wcaxG_BF7rAqeReo2N-29QrtLlRjDZQ_OlGTHrXhoCEG8QAvD_BwE&_gl=1*1d5pbom*_ga*MjM1NTU3MDEwLjE2NzY0NjcxNDA.*_ga_9J976DJZ68*MTY3ODI3MzM1MS4zNy4xLjE2NzgyNzM2ODQuNjAuMC4w).
