### PR TITLE
chore: the file field in the storage annotation id depercated, replaced by value

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/analytics/Settings.java
+++ b/src/main/java/org/jboss/tools/intellij/analytics/Settings.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 @State(
     name = "Settings",
     storages = {
-      @Storage(file = "analytics.settings.xml", roamingType = RoamingType.DISABLED)
+      @Storage(value = "analytics.settings.xml", roamingType = RoamingType.DISABLED)
 })
 public final class Settings implements ICookie, PersistentStateComponent<Settings> {
 


### PR DESCRIPTION
Storage configuration, file has been deprecated and replaced by value.
[View Doc](https://plugins.jetbrains.com/docs/intellij/persisting-state-of-components.html#defining-the-storage-location).

