### PR TITLE
fix: version 2022.3 breaks by marking PreloadingActivity for internal usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ publishPlugin {
 }
 
 dependencies {
-    implementation 'com.github.ballerina-platform:lsp4intellij:master-SNAPSHOT'
+    implementation 'com.github.ballerina-platform:lsp4intellij:0.95.1'
     implementation 'org.kohsuke:github-api:1.314'
     implementation 'org.apache.commons:commons-compress:1.21'
     testImplementation('junit:junit:4.13.1')

--- a/src/main/java/org/jboss/tools/intellij/analytics/GitHubReleaseDownloader.java
+++ b/src/main/java/org/jboss/tools/intellij/analytics/GitHubReleaseDownloader.java
@@ -3,7 +3,7 @@ package org.jboss.tools.intellij.analytics;
 import java.io.File;
 import java.io.IOException;
 
-import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.util.io.HttpRequests;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder.ActionMessage;
 import com.intellij.openapi.diagnostic.Logger;
@@ -36,7 +36,7 @@ public class GitHubReleaseDownloader {
   }
 
 
-  public File download(final ProgressIndicator indicator) throws IOException {
+  public File download() throws IOException {
     final ActionMessage telemetry;
     final String latestReleaseTag;
     final File dest = new File(Platform.pluginDirectory, fileName);
@@ -72,7 +72,7 @@ public class GitHubReleaseDownloader {
       HttpRequests
         .request(url)
         .productNameAsUserAgent()
-        .saveToFile(dest, indicator);
+        .saveToFile(dest, ProgressManager.getGlobalProgressIndicator());
 
       dest.setExecutable(true);
       cookies.setValue(cookieName, latestReleaseTag);

--- a/src/main/java/org/jboss/tools/intellij/analytics/PreloadLanguageServer.java
+++ b/src/main/java/org/jboss/tools/intellij/analytics/PreloadLanguageServer.java
@@ -4,13 +4,14 @@ import java.io.File;
 import java.io.IOException;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.PreloadingActivity;
-import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.IntellijLanguageClient;
 
-public final class PreloadLanguageServer extends PreloadingActivity {
+public final class PreloadLanguageServer implements StartupActivity.Background {
   private static final Logger log = Logger.getInstance(PreloadLanguageServer.class);
   private final ICookie cookies = ServiceManager.getService(Settings.class);
 
@@ -27,11 +28,13 @@ public final class PreloadLanguageServer extends PreloadingActivity {
   }
 
   @Override
-  public void preload(ProgressIndicator indicator) {
+  public void runActivity(@NotNull Project project) {
     if (ApplicationManager.getApplication().isUnitTestMode()) {
       return;
     }
-    log.debug("lsp preload called");
+
+    log.info("lsp preload called");
+
     try {
       final String devUrl = System.getenv("ANALYTICS_LSP_FILE_PATH");
       File lspBundle;
@@ -39,11 +42,13 @@ public final class PreloadLanguageServer extends PreloadingActivity {
         lspBundle = new File(devUrl);
       } else {
         final GitHubReleaseDownloader bundle = new GitHubReleaseDownloader(
-                Platform.current.lspBundleName,
-                cookies,
-                "fabric8-analytics/fabric8-analytics-lsp-server",
-                false);
-        lspBundle = bundle.download(indicator);
+          Platform.current.lspBundleName,
+          cookies,
+          "fabric8-analytics/fabric8-analytics-lsp-server",
+          false);
+        lspBundle = bundle.download();
+
+        log.info("lsp binary is ready for use.");
       }
       attachLanguageClient(lspBundle);
     } catch(IOException ex) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,13 +123,24 @@
   <depends>com.redhat.devtools.intellij.telemetry</depends>
 
   <extensions defaultExtensionNs="com.intellij">
+    <postStartupActivity implementation="org.jboss.tools.intellij.analytics.PreloadLanguageServer"/>
+    <postStartupActivity implementation="org.jboss.tools.intellij.stackanalysis.PreloadCli"/>
+    <!-- register intellijLanguageClient as a Service -->
+    <applicationService serviceImplementation="org.wso2.lsp4intellij.IntellijLanguageClient"/>
+    <!-- register a listener on editor events, required for lsp file sync -->
+    <editorFactoryListener implementation="org.wso2.lsp4intellij.listeners.LSPEditorListener"/>
+    <fileDocumentManagerListener implementation="org.wso2.lsp4intellij.listeners.LSPFileDocumentManagerListener"/>
+    <!-- for displaying notifications by lsp -->
+     <notificationGroup id="lsp" displayType="STICKY_BALLOON"/>
+    <!-- for displaying the statusbar lsp icon -->
+    <statusBarWidgetFactory implementation="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                            id="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                            order="first" />
+    <!-- needed for code diagnostics by lsp -->
     <externalAnnotator id="LSPAnnotator-xml" language="XML" implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
     <externalAnnotator id="LSPAnnotator-json" language="JSON" implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
     <externalAnnotator id="LSPAnnotator-txt" language="TEXT" implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
-    <preloadingActivity implementation="org.jboss.tools.intellij.analytics.PreloadLanguageServer"
-                id="org.jboss.tools.intellij.analytics.PostStartupActivity"/>
-    <preloadingActivity implementation="org.jboss.tools.intellij.stackanalysis.PreloadCli"
-                        id="org.jboss.tools.intellij.analytics.PostStartupCliActivity"/>
+
     <fileEditorProvider implementation="org.jboss.tools.intellij.stackanalysis.SaReportEditorProvider"/>
     <editorTabTitleProvider implementation="org.jboss.tools.intellij.stackanalysis.SaEditorTabTitleProvider" order="first"/>
   </extensions>
@@ -148,9 +159,12 @@
     </group>
   </actions>
 
-  <application-components>
-    <component>
-      <implementation-class>org.wso2.lsp4intellij.IntellijLanguageClient</implementation-class>
-    </component>
-  </application-components>
+  <applicationListeners>
+    <!-- required for lsp file sync -->
+    <listener class="org.wso2.lsp4intellij.listeners.VFSListener"
+              topic="com.intellij.openapi.vfs.VirtualFileListener"/>
+    <listener class="org.wso2.lsp4intellij.listeners.LSPProjectManagerListener"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+  </applicationListeners>
+
 </idea-plugin>


### PR DESCRIPTION
Fixes #76, Fixes #81, Fixes #91, Fixes #92

**Tested locally with versions**:

2021.1 (our minimum target)
2022.2
2022.3 (the latest version)
