### PR TITLE
fix: version 2022.3 breaks by marking PreloadingActivity for internal usage

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/analytics/GitHubReleaseDownloader.java
+++ b/src/main/java/org/jboss/tools/intellij/analytics/GitHubReleaseDownloader.java
@@ -3,7 +3,7 @@ package org.jboss.tools.intellij.analytics;
 import java.io.File;
 import java.io.IOException;
 
-import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.util.io.HttpRequests;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder.ActionMessage;
 import com.intellij.openapi.diagnostic.Logger;
@@ -36,7 +36,7 @@ public class GitHubReleaseDownloader {
   }
 
 
-  public File download(final ProgressIndicator indicator) throws IOException {
+  public File download() throws IOException {
     final ActionMessage telemetry;
     final String latestReleaseTag;
     final File dest = new File(Platform.pluginDirectory, fileName);
@@ -72,7 +72,7 @@ public class GitHubReleaseDownloader {
       HttpRequests
         .request(url)
         .productNameAsUserAgent()
-        .saveToFile(dest, indicator);
+        .saveToFile(dest, ProgressManager.getGlobalProgressIndicator());
 
       dest.setExecutable(true);
       cookies.setValue(cookieName, latestReleaseTag);

--- a/src/main/java/org/jboss/tools/intellij/stackanalysis/PreloadCli.java
+++ b/src/main/java/org/jboss/tools/intellij/stackanalysis/PreloadCli.java
@@ -10,12 +10,11 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.stackanalysis;
 
+import com.intellij.ide.AppLifecycleListener;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.PreloadingActivity;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProcessCanceledException;
-import com.intellij.openapi.progress.ProgressIndicator;
 import org.jboss.tools.intellij.analytics.GitHubReleaseDownloader;
 import org.jboss.tools.intellij.analytics.ICookie;
 import org.jboss.tools.intellij.analytics.Platform;
@@ -23,51 +22,42 @@ import org.jboss.tools.intellij.analytics.Settings;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.util.List;
 
-
-public final class PreloadCli extends PreloadingActivity {
+public final class PreloadCli implements AppLifecycleListener {
   private static final Logger logger = Logger.getInstance(PreloadCli.class);
   private final ICookie cookies = ServiceManager.getService(Settings.class);
 
-  /**
-   * <p> Activity need to be performed when plugin/IDE is started.</p>
-   *
-   * When IDE is started or plugin is installed setup prerequisites for plugin.
-   *
-   * @param indicator An object of ProgressIndicator
-   */
   @Override
-  public void preload(@NotNull ProgressIndicator indicator) {
-    if (ApplicationManager.getApplication().isUnitTestMode()) {
-      return;
-    }
+  public void appFrameCreated(@NotNull List<String> commandLineArgs) {
     logger.info("CLI preload is called");
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      try {
+        // If Env variable is set then use binary file from value given
+        final String cliPath = System.getenv("CLI_FILE_PATH");
 
-    try {
-      // If Env variable is set then use binary file from value given
-      final String cliPath = System.getenv("CLI_FILE_PATH");
+        // If Env variable is not set download binary from GitHub Repo
+        if (cliPath == null) {
+          final GitHubReleaseDownloader bundle = new GitHubReleaseDownloader(
+            Platform.current.cliTarBallName,
+            cookies,
+            "fabric8-analytics/cli-tools",
+            true);
 
-      // If Env variable is not set download binary from GitHub Repo
-      if (cliPath == null) {
-        final GitHubReleaseDownloader bundle = new GitHubReleaseDownloader(
-                Platform.current.cliTarBallName,
-                cookies,
-                "fabric8-analytics/cli-tools",
-                true);
+          // Download the CLI tarball
+          bundle.download();
 
-        // Download the CLI tarball
-        bundle.download(indicator);
+          // Extract tar file to get CLI Binary
+          new SaUtils().unTarBundle(Platform.current.cliTarBallName, Cli.current.cliBinaryName);
+          logger.info("CLI binary is ready for use.");
+        }
 
-        // Extract tar file to get CLI Binary
-        new SaUtils().unTarBundle(Platform.current.cliTarBallName, Cli.current.cliBinaryName);
-        logger.info("CLI binary is ready for use.");
+        // Authenticate user
+        new SaProcessExecutor().authenticateUser();
+      } catch(IOException | InterruptedException e) {
+        logger.warn(e);
+        throw new ProcessCanceledException(e);
       }
-
-      // Authenticate user
-      new SaProcessExecutor().authenticateUser();
-    } catch(IOException | InterruptedException e) {
-      logger.warn(e);
-      throw new ProcessCanceledException(e);
-    }
+    });
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,13 +123,22 @@
   <depends>com.redhat.devtools.intellij.telemetry</depends>
 
   <extensions defaultExtensionNs="com.intellij">
+    <!-- register intellijLanguageClient as a Service -->
+    <applicationService serviceImplementation="org.wso2.lsp4intellij.IntellijLanguageClient"/>
+    <!-- register a listener on editor events, required for lsp file sync -->
+    <editorFactoryListener implementation="org.wso2.lsp4intellij.listeners.LSPEditorListener"/>
+    <fileDocumentManagerListener implementation="org.wso2.lsp4intellij.listeners.LSPFileDocumentManagerListener"/>
+    <!-- for displaying notifications by lsp -->
+     <notificationGroup id="lsp" displayType="STICKY_BALLOON"/>
+    <!-- for displaying the statusbar lsp icon -->
+    <statusBarWidgetFactory implementation="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                            id="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                            order="first" />
+    <!-- needed for code diagnostics by lsp -->
     <externalAnnotator id="LSPAnnotator-xml" language="XML" implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
     <externalAnnotator id="LSPAnnotator-json" language="JSON" implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
     <externalAnnotator id="LSPAnnotator-txt" language="TEXT" implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
-    <preloadingActivity implementation="org.jboss.tools.intellij.analytics.PreloadLanguageServer"
-                id="org.jboss.tools.intellij.analytics.PostStartupActivity"/>
-    <preloadingActivity implementation="org.jboss.tools.intellij.stackanalysis.PreloadCli"
-                        id="org.jboss.tools.intellij.analytics.PostStartupCliActivity"/>
+
     <fileEditorProvider implementation="org.jboss.tools.intellij.stackanalysis.SaReportEditorProvider"/>
     <editorTabTitleProvider implementation="org.jboss.tools.intellij.stackanalysis.SaEditorTabTitleProvider" order="first"/>
   </extensions>
@@ -148,9 +157,20 @@
     </group>
   </actions>
 
-  <application-components>
-    <component>
-      <implementation-class>org.wso2.lsp4intellij.IntellijLanguageClient</implementation-class>
-    </component>
-  </application-components>
+  <applicationListeners>
+    <!-- required for lsp file sync -->
+    <listener class="org.wso2.lsp4intellij.listeners.VFSListener"
+              topic="com.intellij.openapi.vfs.VirtualFileListener"/>
+    <listener class="org.wso2.lsp4intellij.listeners.LSPProjectManagerListener"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    <!-- download the lsp executable, register, and run it-->
+    <listener class="org.jboss.tools.intellij.analytics.PreloadLanguageServer"
+              topic="com.intellij.ide.AppLifecycleListener"
+              activeInTestMode="false"/>
+    <!-- download the cli executable, extract it, and authenticate with it -->
+    <listener class="org.jboss.tools.intellij.stackanalysis.PreloadCli"
+              topic="com.intellij.ide.AppLifecycleListener"
+              activeInTestMode="false"/>
+  </applicationListeners>
+
 </idea-plugin>


### PR DESCRIPTION
Fixes #35, Fixes #76, Fixes #81, Fixes #91, Fixes #92

**Tested locally with versions**:

- 2021.1 (our minimum target)
- 2022.2
- 2022.3 (the latest version)

**Edit 1**:
Looks like this fix, though fixed the issue at hand, introduced a new one.
With this fix, diagnostic is only performed for modifying an already open file, and not for opening one.

**Edit 2**:
The cause for the error described in _Edit 1_ is _lsp4intellij_.
This bug was introduced in version [0.95.1](https://github.com/ballerina-platform/lsp4intellij/releases/tag/0.95.1), and can be demonstrated using the _master-snapshot_ as well.
However, pinning the version to [0.95.0](https://github.com/ballerina-platform/lsp4intellij/releases/tag/0.95.0) resolves this issue.
Pinning the version is handled in #106.