### PR TITLE
chore: set gradle to always update snapshots version when building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ publishPlugin {
 }
 
 dependencies {
+    configurations.all {
+        // this means SNAPSHOT versions will be updated for every build
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+
     // WATCH OUT - lsp4intellij version 0.95.1 breaks diagnostics for opened files
     implementation 'com.github.ballerina-platform:lsp4intellij:0.95.0'
     constraints {


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

https://docs.gradle.org/current/userguide/dependency_management.html#ex-changing-module-cache-control
