### PR TITLE
test: Added framework for UI integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 	flatDir {
 	    dirs buildDir
@@ -15,6 +16,15 @@ repositories {
             username = project.findProperty("gpr.username") ?: System.getenv("GITHUB_USERNAME")
             password = project.findProperty("gpr.token") ?: System.getenv("GITHUB_TOKEN")
         }
+    }
+    maven {
+        url 'https://repository.jboss.org/nexus/content/repositories/snapshots'
+    }
+    maven {
+        url 'https://repository.jboss.org/nexus/content/groups/public'
+    }
+    maven {
+        url 'https://packages.jetbrains.team/maven/p/ij/intellij-dependencies'
     }
 }
 
@@ -62,6 +72,7 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.21'
     implementation 'com.redhat.crda:crda-java-api:0.0.1-SNAPSHOT'
     testImplementation('junit:junit:4.13.1')
+    implementation 'com.redhat.devtools.intellij:intellij-common-ui-test-library:0.2.0'
 }
 
 runIde {
@@ -70,6 +81,25 @@ runIde {
 
 runIdeForUiTests {
     systemProperties['com.redhat.devtools.intellij.telemetry.mode'] = 'debug'
+}
+
+sourceSets {
+    integrationTest {
+        java.srcDir file('src/it/java')
+        resources.srcDir file('src/it/resources')
+        compileClasspath += sourceSets.main.output + configurations.runtimeClasspath
+        runtimeClasspath += output + compileClasspath
+    }
+}
+
+task integrationTest(type: Test) {
+    useJUnitPlatform()
+    description = 'Runs the integration tests.'
+    group = 'verification'
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    outputs.upToDateWhen { false }
+    mustRunAfter test
 }
 
 group 'org.jboss.tools.intellij'

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/AbstractBaseTest.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/AbstractBaseTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui;
+
+
+import com.intellij.remoterobot.RemoteRobot;
+import com.intellij.remoterobot.utils.WaitForConditionTimeoutException;
+import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.idestatusbar.IdeStatusBar;
+import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.toolwindowspane.ToolWindowsPane;
+import org.jboss.tools.intellij.analytics.test.ui.annotations.UITest;
+import org.jboss.tools.intellij.analytics.test.ui.junit.TestRunnerExtension;
+import org.jboss.tools.intellij.analytics.test.ui.runner.IdeaRunner;
+import org.jboss.tools.intellij.analytics.test.ui.utils.ProjectUtility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+
+/**
+ * @author Ondrej Dockal, odockal@redhat.com
+ */
+@ExtendWith(TestRunnerExtension.class)
+@UITest
+abstract public class AbstractBaseTest {
+
+    private static RemoteRobot robot;
+    @BeforeAll
+    public static void connect() {
+        robot = IdeaRunner.getInstance().getRemoteRobot();
+        ProjectUtility.copyProjectFromVSC(robot);
+        ProjectUtility.closeTipDialogIfItAppears(robot);
+        //ProjectStructureDialog.cancelProjectStructureDialogIfItAppears(robot);
+        ProjectUtility.closeGotItPopup(robot);
+        IdeStatusBar ideStatusBar = robot.find(IdeStatusBar.class, Duration.ofSeconds(5));
+        ideStatusBar.waitUntilAllBgTasksFinish();
+    }
+
+    public RemoteRobot getRobotReference() {
+        return robot;
+    }
+
+    public boolean isStripeButtonAvailable(String label) {
+        try {
+            ToolWindowsPane toolWindowsPane = robot.find(ToolWindowsPane.class);
+            toolWindowsPane.stripeButton(label, false);
+        } catch (WaitForConditionTimeoutException e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/BaseUITest.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/BaseUITest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui;
+
+import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.toolwindowspane.ProjectExplorer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Richard Kocian
+ */
+public class BaseUITest extends AbstractBaseTest {
+
+	@Test
+	public void checkIfPomExists() {
+		ProjectExplorer projectExplorer = getRobotReference().find(ProjectExplorer.class);
+		String[] path = new String[]{"pom.xml"};
+		assertTrue(projectExplorer.projectViewTree().isPathExists(path, true));
+	}
+
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/annotations/UITest.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/annotations/UITest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui.annotations;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Ondrej Dockal
+ * Annotation represent UI Test class, using @Tag annotation
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("ui-test")
+public @interface UITest {
+
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/dialogs/ProjectStructureDialog.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/dialogs/ProjectStructureDialog.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui.dialogs;
+
+import com.intellij.remoterobot.RemoteRobot;
+import com.intellij.remoterobot.data.RemoteComponent;
+import com.intellij.remoterobot.fixtures.CommonContainerFixture;
+import com.intellij.remoterobot.fixtures.DefaultXpath;
+import com.intellij.remoterobot.fixtures.FixtureName;
+import com.intellij.remoterobot.utils.WaitForConditionTimeoutException;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * Project Structure dialog fixture
+ *
+ * @author olkornii@redhat.com
+ */
+@DefaultXpath(by = "MyDialog type", xpath = "//div[@accessiblename='Project Structure' and @class='MyDialog']")
+@FixtureName(name = "Project Structure Dialog")
+public class ProjectStructureDialog extends CommonContainerFixture {
+    public ProjectStructureDialog(@NotNull RemoteRobot remoteRobot, @NotNull RemoteComponent remoteComponent) {
+        super(remoteRobot, remoteComponent);
+    }
+
+    /**
+     * Cancel the 'Project Structure' dialog if it appears
+     *
+     * @param remoteRobot reference to the RemoteRobot instance
+     */
+    public static void cancelProjectStructureDialogIfItAppears(RemoteRobot remoteRobot) {
+        try {
+            ProjectStructureDialog projectStructureDialog = remoteRobot.find(ProjectStructureDialog.class, Duration.ofSeconds(20));
+            projectStructureDialog.button("Cancel").click();
+        } catch (WaitForConditionTimeoutException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/junit/TestRunnerExtension.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/junit/TestRunnerExtension.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui.junit;
+
+import com.redhat.devtools.intellij.commonuitest.UITestRunner;
+import com.redhat.devtools.intellij.commonuitest.utils.runner.IntelliJVersion;
+import org.jboss.tools.intellij.analytics.test.ui.runner.IdeaRunner;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+
+/**
+ * JUnit 5 test extension providing wrapper for tests and initiate connection to IDEA under test
+ * @author Ondrej Dockal
+ *
+ */
+public class TestRunnerExtension implements BeforeAllCallback, CloseableResource {
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		System.out.println("Initialize IdeaRunner and start IDE");
+		// need to initialize store, so that close method will be called at the testing end
+		context.getRoot().getStore(Namespace.GLOBAL).put("InitializeTest", this);
+		IdeaRunner.getInstance().startIDE(IntelliJVersion.COMMUNITY_V_2022_1, 8580);
+	}
+
+	@Override
+	public void close() {
+		System.out.println("Closing IDE");
+		UITestRunner.closeIde();
+
+	}
+
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/runner/IdeaRunner.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/runner/IdeaRunner.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui.runner;
+
+import com.intellij.remoterobot.RemoteRobot;
+import com.redhat.devtools.intellij.commonuitest.UITestRunner;
+import com.redhat.devtools.intellij.commonuitest.utils.runner.IntelliJVersion;
+
+/**
+ * Idea Runner singleton to keep track of running IDE
+ * @author Ondrej Dockal
+ *
+ */
+public class IdeaRunner {
+
+	private static IdeaRunner ideaRunner = null;
+	private static boolean ideaIsStarted = false;
+	private static int port = 8580;
+
+	private RemoteRobot robot;
+	
+	private IdeaRunner() {}
+	
+	public static IdeaRunner getInstance() {
+		if (ideaRunner == null) {
+			ideaRunner = new IdeaRunner();
+		}
+		return ideaRunner;
+	}
+	
+	public void startIDE(IntelliJVersion ideaVersion, int portNumber) {
+		if (!ideaIsStarted) {
+			System.out.println("Starting IDE, setting ideaIsStarted to true");
+			robot = UITestRunner.runIde(ideaVersion, port);
+			port = portNumber;
+			System.out.println("IDEA port for remote robot: " + port);
+			ideaIsStarted = true;
+		}
+	}
+
+	public RemoteRobot getRemoteRobot() {
+		return robot;
+	}
+
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
@@ -71,7 +71,7 @@ public class ProjectUtility {
 
     public static void clickOnTrustProjectIfAppears(RemoteRobot robot) {
         try {
-            JButtonFixture trustProjectButton = robot.find(JButtonFixture.class, byXpath("//div[@text.key='untrusted.project.dialog.trust.button']"));
+            JButtonFixture trustProjectButton = robot.find(JButtonFixture.class, byXpath("//div[@text.key='untrusted.project.dialog.trust.button']"), Duration.ofSeconds(20));
             trustProjectButton.click();
         } catch (WaitForConditionTimeoutException e) {
             // no dialog appeared, no need to exception handling

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.intellij.analytics.test.ui.utils;
+
+import com.intellij.remoterobot.RemoteRobot;
+import com.intellij.remoterobot.fixtures.ComponentFixture;
+import com.intellij.remoterobot.fixtures.JButtonFixture;
+import com.intellij.remoterobot.fixtures.JTextFieldFixture;
+import com.intellij.remoterobot.utils.WaitForConditionTimeoutException;
+import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.FlatWelcomeFrame;
+import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.information.TipDialog;
+import com.redhat.devtools.intellij.commonuitest.fixtures.dialogs.project.NewProjectDialogWizard;
+import com.redhat.devtools.intellij.commonuitest.fixtures.mainidewindow.idestatusbar.IdeStatusBar;
+
+import java.time.Duration;
+
+import static com.intellij.remoterobot.search.locators.Locators.byXpath;
+
+/**
+ * @author Ondrej Dockal, Oleksii Korniienko, Ihor Okhrimenko, Richard Kocian
+ */
+public class ProjectUtility {
+
+
+
+    public static void createEmptyProject(RemoteRobot robot, String projectName) {
+        final FlatWelcomeFrame flatWelcomeFrame = robot.find(FlatWelcomeFrame.class);
+        flatWelcomeFrame.createNewProject();
+        final NewProjectDialogWizard newProjectDialogWizard = flatWelcomeFrame.find(NewProjectDialogWizard.class, Duration.ofSeconds(20));
+        selectNewProjectType(robot, "Empty Project");
+        newProjectDialogWizard.next();
+        JTextFieldFixture textField = robot.find(JTextFieldFixture.class, byXpath("//div[@visible_text='untitled']"));
+        textField.setText(projectName);
+        newProjectDialogWizard.finish();
+        final IdeStatusBar ideStatusBar = robot.find(IdeStatusBar.class, Duration.ofSeconds(5));
+        ideStatusBar.waitUntilProjectImportIsComplete();
+    }
+
+    public static void selectNewProjectType(RemoteRobot robot, String projectType) {
+        ComponentFixture newProjectTypeList = robot.findAll(ComponentFixture.class, byXpath("JBList", "//div[contains(@visible_text, 'FX')]")).get(0);
+        newProjectTypeList.findText(projectType).click();
+    }
+
+    public static void copyProjectFromVSC(RemoteRobot robot) {
+        final FlatWelcomeFrame flatWelcomeFrame = robot.find(FlatWelcomeFrame.class);
+        flatWelcomeFrame.clearWorkspace();
+        JButtonFixture copyProjectFromVSCList = robot.findAll(JButtonFixture.class, byXpath("//div[@accessiblename='Get from VCS' and @accessiblename.key='Vcs.VcsClone.Tabbed.Welcome.text' and @class='JBOptionButton' and @text='Get from VCS' and @text.key='Vcs.VcsClone.Tabbed.Welcome.text']")).get(0);
+        copyProjectFromVSCList.click();
+        JTextFieldFixture textField = robot.find(JTextFieldFixture.class, byXpath("//div[@class='BorderlessTextField']"));
+        textField.click();
+
+        textField.setText("https://github.com/devfile-samples/devfile-sample-java-springboot-basic.git");
+
+        JButtonFixture buttonFixture = robot.find(JButtonFixture.class, byXpath("//div[@text.key='clone.dialog.clone.button']"));
+        buttonFixture.click();
+
+        clickOnTrustProjectIfAppears(robot);
+
+        final IdeStatusBar ideStatusBar = robot.find(IdeStatusBar.class, Duration.ofSeconds(5));
+        ideStatusBar.waitUntilProjectImportIsComplete();
+    }
+
+
+    public static void clickOnTrustProjectIfAppears(RemoteRobot robot) {
+        try {
+            JButtonFixture trustProjectButton = robot.find(JButtonFixture.class, byXpath("//div[@text.key='untrusted.project.dialog.trust.button']"));
+            trustProjectButton.click();
+        } catch (WaitForConditionTimeoutException e) {
+            // no dialog appeared, no need to exception handling
+        }
+    }
+
+    public static void closeTipDialogIfItAppears(RemoteRobot robot) {
+        try {
+            TipDialog tipDialog = robot.find(TipDialog.class, Duration.ofSeconds(10));
+//            tipDialog.close(); // temporary commented
+            robot.find(ComponentFixture.class, byXpath("//div[@accessiblename='Close' and @class='JButton' and @text='Close']"), Duration.ofSeconds(5)).click(); // temporary workaround
+        } catch (WaitForConditionTimeoutException e) {
+            // no dialog appeared, no need to exception handling
+        }
+    }
+
+    public static void closeGotItPopup(RemoteRobot robot) {
+        try {
+            robot.find(ComponentFixture.class, byXpath("JBList", "//div[@accessiblename='Got It' and @class='JButton' and @text='Got It']"), Duration.ofSeconds(10)).click();
+        } catch (WaitForConditionTimeoutException e) {
+            // no dialog appeared, no need to exception handling
+        }
+    }
+
+    public static void sleep(long ms) {
+        System.out.println("Putting thread into sleep for: " + ms + " ms");
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
@@ -52,7 +52,7 @@ public class ProjectUtility {
     public static void copyProjectFromVSC(RemoteRobot robot) {
         final FlatWelcomeFrame flatWelcomeFrame = robot.find(FlatWelcomeFrame.class);
         flatWelcomeFrame.clearWorkspace();
-        JButtonFixture copyProjectFromVSCList = robot.findAll(JButtonFixture.class, byXpath("//div[@accessiblename='Get from VCS' and @accessiblename.key='Vcs.VcsClone.Tabbed.Welcome.text' and @class='JBOptionButton' and @text='Get from VCS' and @text.key='Vcs.VcsClone.Tabbed.Welcome.text']")).get(0);
+        JButtonFixture copyProjectFromVSCList = robot.find(JButtonFixture.class, byXpath("//div[@accessiblename.key='action.Vcs.VcsClone.text']"));
         copyProjectFromVSCList.click();
         JTextFieldFixture textField = robot.find(JTextFieldFixture.class, byXpath("//div[@class='BorderlessTextField']"));
         textField.click();

--- a/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
+++ b/src/it/java/org/jboss/tools/intellij/analytics/test/ui/utils/ProjectUtility.java
@@ -50,8 +50,6 @@ public class ProjectUtility {
     }
 
     public static void copyProjectFromVSC(RemoteRobot robot) {
-        final FlatWelcomeFrame flatWelcomeFrame = robot.find(FlatWelcomeFrame.class);
-        flatWelcomeFrame.clearWorkspace();
         JButtonFixture copyProjectFromVSCList = robot.find(JButtonFixture.class, byXpath("//div[@accessiblename.key='action.Vcs.VcsClone.text']"));
         copyProjectFromVSCList.click();
         JTextFieldFixture textField = robot.find(JTextFieldFixture.class, byXpath("//div[@class='BorderlessTextField']"));


### PR DESCRIPTION
Added basic dummy test, which will create and open new instance of IntelliJ, import the [devfile-sample-java-springboot-basic ](https://github.com/devfile-samples/devfile-sample-java-springboot-basic) project and then it will run one basic test case which will only check that the pom.xml file is present in the project files.

Steps to run UI integration tests:
1) Clone my forked repo: git clone -b ui-tests https://github.com/richard0202/intellij-dependency-analytics.git
2) Navigate to the cloned folder: cd intellij-dependency-analytics
3) Execute integration tests: ./gradlew integrationTest
4) It should fail, but it will create folder **build** inside folder i**ntellij-dependency-analytics**
5) Copy **crda-java-api-0.0.1-SNAPSHOT.jar** into the **build** folder (crda-java-api-0.0.1-SNAPSHOT.jar can be found inside https://github.com/redhat-developer/intellij-dependency-analytics/releases/tag/early-access zip)
6) Execute integration tests again: ./gradlew integrationTest

Keep in mind that running these tests will permanently delete all folders inside **~/IdeaProjects/**

New test cases can be added inside the BaseUITest.java or in new class (in this case do not forget to extend that class with AbstractBaseTest class).