### PR TITLE
chore: release Intelli-J dependency analytics version 0.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion = IC-2021.1
-projectVersion=0.7.0-SNAPSHOT
+projectVersion=0.7.0
 jetBrainsToken=invalid
 jetBrainsChannel=stable


### PR DESCRIPTION
Change gradle.properties' projectVersion to be without suffix of "-SNAPSHOT" in order to enforce jenkins pipeline to release it to the stable channel.