### PR TITLE
feat: add CAUpdateManifestIntentionAction mechanism to update manifests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 
     implementation 'org.kohsuke:github-api:1.314'
     implementation 'org.apache.commons:commons-compress:1.21'
-    implementation 'com.redhat.exhort:exhort-java-api:0.0.4-SNAPSHOT'
+    implementation 'com.redhat.exhort:exhort-java-api:0.0.5-SNAPSHOT'
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 
     testImplementation('junit:junit:4.13.1')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion = 2021.1
-projectVersion=0.9.0-SNAPSHOT
+projectVersion=0.7.1-SNAPSHOT
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion = 2021.1
-projectVersion=0.7.1-SNAPSHOT
+projectVersion=0.9.0-SNAPSHOT
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -159,9 +159,11 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
                                                 .newAnnotation(getHighlightSeverity(report), messageBuilder.toString())
                                                 .tooltip(tooltipBuilder.toString())
                                                 .range(e);
+                                        CAUpdateManifestIntentionAction patchManifest = this.patchManifest(file, report);
                                         builder.withFix(new SAIntentionAction());
                                             builder.withFix(this.createQuickFix(e, source, report));
-                                            builder.create();
+                                            builder.withFix(patchManifest);
+                                        builder.create();
                                       }
                                     );
                                 }
@@ -191,7 +193,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
     abstract protected Map<Dependency, List<PsiElement>> getDependencies(PsiFile file);
 
     abstract protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report);
-
+    abstract protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport report);
     abstract protected boolean isQuickFixApplicable(PsiElement element);
 
     private Map<Dependency, Result> matchDependencies(Map<Dependency, List<PsiElement>> dependencies,

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAIntentionAction.java
@@ -87,10 +87,9 @@ public abstract class CAIntentionAction implements IntentionAction {
     }
 
     protected abstract void updateVersion(@NotNull Project project, Editor editor, PsiFile file, String version);
-
     protected abstract @Nullable FileModifier createCAIntentionActionInCopy(PsiElement element);
 
-    //TODO
+
     private static @NotNull String getRecommendedVersion(DependencyReport dependency) {
         String version=null;
         if(thereAreNoIssues(dependency))

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAUpdateManifestIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAUpdateManifestIntentionAction.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.intellij.componentanalysis;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import com.redhat.exhort.api.DependencyReport;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class CAUpdateManifestIntentionAction implements IntentionAction {
+
+    protected @SafeFieldForPreview PsiElement element;
+    protected @SafeFieldForPreview DependencyReport dependency;
+
+
+    protected CAUpdateManifestIntentionAction(PsiElement element, DependencyReport dependency) {
+        this.element = element;
+        this.dependency = dependency;
+    }
+
+    @Override
+    public @IntentionName @NotNull String getText() {
+        return this.getTextImpl();
+    }
+
+    protected abstract String getTextImpl();
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return "RHDA";
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        this.updateManifest(project, editor, file, this.dependency);
+    }
+
+    protected abstract void updateManifest(Project project, Editor editor, PsiFile file, DependencyReport dependency);
+
+    @Override
+    public boolean startInWriteAction() {
+        return true;
+    }
+
+    
+}

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/golang/GoCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/golang/GoCAAnnotator.java
@@ -19,10 +19,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.redhat.exhort.api.DependencyReport;
-import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
-import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
-import org.jboss.tools.intellij.componentanalysis.Dependency;
-import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jboss.tools.intellij.componentanalysis.*;
 
 import java.util.*;
 
@@ -79,6 +76,11 @@ public class GoCAAnnotator extends CAAnnotator {
     @Override
     protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report) {
         return new GoCAIntentionAction(element, source, report);
+    }
+
+    @Override
+    protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport report) {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAAnnotator.java
@@ -18,10 +18,7 @@ import com.intellij.psi.xml.XmlDocument;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.psi.xml.XmlText;
 import com.redhat.exhort.api.DependencyReport;
-import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
-import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
-import org.jboss.tools.intellij.componentanalysis.Dependency;
-import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jboss.tools.intellij.componentanalysis.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -115,6 +112,11 @@ public class MavenCAAnnotator extends CAAnnotator {
     @Override
     protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report) {
         return new MavenCAIntentionAction(element, source, report);
+    }
+
+    @Override
+    protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport dependency) {
+        return new MavenCAUpdateManifestIntentionAction(element,dependency);
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAUpdateManifestIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAUpdateManifestIntentionAction.java
@@ -1,0 +1,121 @@
+package org.jboss.tools.intellij.componentanalysis.maven;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.impl.source.xml.XmlTagImpl;
+import com.intellij.psi.xml.XmlDocument;
+import com.intellij.psi.xml.XmlTag;
+import com.intellij.psi.xml.XmlText;
+import com.intellij.xml.util.XmlUtil;
+import com.redhat.exhort.api.DependencyReport;
+import com.redhat.exhort.api.PackageRef;
+import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
+import org.jetbrains.annotations.NotNull;
+
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlValue;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class MavenCAUpdateManifestIntentionAction extends CAUpdateManifestIntentionAction {
+    @Override
+    protected String getTextImpl() {
+        return "Add Redhat GA Maven Repository to your pom.xml";
+    }
+
+    MavenCAUpdateManifestIntentionAction(PsiElement element, DependencyReport report) {
+        super(element, report);
+    }
+
+    @Override
+    protected void updateManifest(Project project, Editor editor, PsiFile file, DependencyReport dependency) {
+        PsiElement rootProjectElement = getRootPomElement(file);
+        XmlTag repositories = new XmlTagImpl();
+        XmlTag rootProjectXml = (XmlTag)rootProjectElement;
+        if(Arrays.stream(rootProjectElement.getChildren()).noneMatch(psi -> psi instanceof XmlTag && ((XmlTag)psi).getName().equals("repositories"))) {
+
+            repositories = rootProjectXml.createChildTag("repositories",rootProjectXml.getNamespace(),"",false);
+            repositories.setName("repositories");
+
+        }
+        else {
+            Optional<PsiElement> repoWrapper = Arrays.stream(rootProjectElement.getChildren()).filter(psi -> psi instanceof XmlTag && ((XmlTag) psi).getName().equals("repositories")).findFirst();
+            if(repoWrapper.isPresent()) {
+                repositories = (XmlTag)repoWrapper.get();
+            }
+        }
+
+        XmlTag repository = repositories.createChildTag("repository", repositories.getNamespace(), "", false);
+        repository.setName("repository");
+
+        XmlTag id = repository.createChildTag("id", repository.getNamespace(), "redhat-ga", false);
+        XmlTag name = repository.createChildTag("name", repository.getNamespace(), "Redhat GA Maven Repository", false);
+        XmlTag url = repository.createChildTag("url", repository.getNamespace(), getRepositoryUrl(dependency), false);
+        id.setName("id");
+        name.setName("name");
+        url.setName("url");
+        id.getValue().setText("redhat-ga");
+        name.getValue().setText("Redhat GA Maven Repository");
+        url.getValue().setText(getRepositoryUrl(dependency));
+        repository.addSubTag(id,false);
+        repository.addSubTag(name,false);
+        repository.addSubTag(url,false);
+        // only after subtags created and populated, add them as subtags, so outer tags will be populated with their values.
+        repositories.addSubTag(repository,true);
+        rootProjectXml.addSubTag(repositories,true);
+
+    }
+
+    @NotNull
+    private static PsiElement getRootPomElement(PsiFile file) {
+        PsiElement rootProjectElement = Arrays.stream(file.getChildren())
+                .filter(element -> element instanceof XmlDocument)
+                .flatMap(element -> Arrays.stream(element.getChildren()))
+                .filter(element -> element instanceof XmlTag && "project".equals(((XmlTag) element).getName())).findFirst().get();
+        return rootProjectElement;
+    }
+
+    private static String getRepositoryUrl(DependencyReport dependency) {
+        return getRepositoryUrlFromPurl(dependency);
+    }
+
+    private static String getRepositoryUrlFromPurl(DependencyReport dependency) {
+        AtomicReference<PackageRef> packageRef = new AtomicReference<>();
+        if(Objects.nonNull(dependency.getRecommendation()))
+        {
+            packageRef.set(dependency.getRecommendation());
+        }
+        else {
+            dependency.getIssues().stream().filter(issue -> Objects.nonNull(issue.getRemediation().getTrustedContent())).findFirst().ifPresent( value -> packageRef.set(value.getRemediation().getTrustedContent().getRef()));
+        }
+        return packageRef.get().purl().getQualifiers().get("repository_url");
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        boolean manifestIsPomXml = file != null && "pom.xml".equals(file.getName());
+        boolean repositoryInPom = false;
+        PsiElement rootPomElement = getRootPomElement(file);
+        Optional<PsiElement> repoWrapper = Arrays.stream(rootPomElement.getChildren()).filter(psi -> psi instanceof XmlTag && ((XmlTag) psi).getName().equals("repositories")).findFirst();
+        if (repoWrapper.isPresent()) {
+             XmlTag repositories = (XmlTag) repoWrapper.get();
+            repositoryInPom = Arrays.stream(repositories.getChildren())
+                    .flatMap(element -> Arrays.stream(element.getChildren()))
+                    .filter(element -> element instanceof XmlTag && "id".equals(((XmlTag) element).getName()))
+                    .flatMap(tagValue -> Arrays.stream(((XmlTag) tagValue).getValue().getChildren()))
+                    .anyMatch(tag -> tag instanceof XmlText && (((XmlText) tag).getValue().trim().equals("redhat-ga")));
+
+        }
+
+        return manifestIsPomXml && !repositoryInPom;
+
+    }
+}

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/npm/NpmCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/npm/NpmCAAnnotator.java
@@ -15,10 +15,7 @@ import com.intellij.json.psi.*;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.exhort.api.DependencyReport;
-import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
-import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
-import org.jboss.tools.intellij.componentanalysis.Dependency;
-import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jboss.tools.intellij.componentanalysis.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -78,6 +75,11 @@ public class NpmCAAnnotator extends CAAnnotator {
     @Override
     protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report) {
         return new NpmCAIntentionAction(element, source, report);
+    }
+
+    @Override
+    protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport report) {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/pypi/ce/PipCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/pypi/ce/PipCAAnnotator.java
@@ -14,10 +14,7 @@ package org.jboss.tools.intellij.componentanalysis.pypi.ce;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.redhat.exhort.api.DependencyReport;
-import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
-import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
-import org.jboss.tools.intellij.componentanalysis.Dependency;
-import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jboss.tools.intellij.componentanalysis.*;
 import org.jboss.tools.intellij.componentanalysis.pypi.PipCAInspection;
 import org.jboss.tools.intellij.componentanalysis.pypi.ce.requirements.psi.NameReq;
 import org.jboss.tools.intellij.componentanalysis.pypi.ce.requirements.psi.NameReqComment;
@@ -61,6 +58,11 @@ public class PipCAAnnotator extends CAAnnotator {
     @Override
     protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report) {
         return new PipCAIntentionAction(element, source, report);
+    }
+
+    @Override
+    protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport report) {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/pypi/pro/PipCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/pypi/pro/PipCAAnnotator.java
@@ -16,10 +16,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.redhat.exhort.api.DependencyReport;
-import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
-import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
-import org.jboss.tools.intellij.componentanalysis.Dependency;
-import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jboss.tools.intellij.componentanalysis.*;
 import org.jboss.tools.intellij.componentanalysis.pypi.PipCAInspection;
 import org.jetbrains.annotations.Nullable;
 import ru.meanmail.psi.NameReq;
@@ -82,6 +79,11 @@ public class PipCAAnnotator extends CAAnnotator {
     @Override
     protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report) {
         return new PipCAIntentionAction(element, source, report);
+    }
+
+    @Override
+    protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport report) {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
add CAUpdateManifestIntentionAction mechanism to add an updateManifest annotation, so it will add some general information to manifest from data retrieved from dependencies
 and create CAUpdateManifestIntentionAction subclass to add redhat ga repository to pom.xml