### PR TITLE
chore(skip-release): prepare for 1.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 ideaVersion = 2022.1
-projectVersion=1.0.0-SNAPSHOT
+projectVersion=1.0.0
 jetBrainsToken=invalid
 jetBrainsChannel=stable


### PR DESCRIPTION
@zvigrinberg The version is bumped to 1.0.0.
Please review and merge this PR, then we can trigger the release.