### PR TITLE
feat: added recommendation acceptance tracking

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -241,7 +241,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
         return profile.getUnwrappedTool(inspectionShortName, context);
     }
 
-    private String getPackageManager(String file) {
+    public static String getPackageManager(String file) {
         switch (file) {
             case "pom.xml":
                 return "maven";

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAIntentionAction.java
@@ -23,6 +23,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.redhat.exhort.api.DependencyReport;
 import com.redhat.exhort.api.Issue;
+import org.jboss.tools.intellij.exhort.TelemetryService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,7 +53,9 @@ public abstract class CAIntentionAction implements IntentionAction {
 
     @Override
     public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
-        this.updateVersion(project, editor, file, getRecommendedVersion(this.report));
+        String recommendedVersion = getRecommendedVersion(this.report);
+        this.updateVersion(project, editor, file, recommendedVersion);
+        TelemetryService.sendPackageUpdateEvent(file, recommendedVersion, this.report.getRef().name(), "recommendation-accepted");
     }
 
     private String getRecommendationsRepo(DependencyReport dependency) {

--- a/src/main/java/org/jboss/tools/intellij/exhort/TelemetryService.java
+++ b/src/main/java/org/jboss/tools/intellij/exhort/TelemetryService.java
@@ -10,8 +10,12 @@
  ******************************************************************************/
 package org.jboss.tools.intellij.exhort;
 
+import com.intellij.psi.PsiFile;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import com.redhat.devtools.intellij.telemetry.core.util.Lazy;
+import com.redhat.exhort.api.DependencyReport;
+import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
+import org.jboss.tools.intellij.settings.ApiSettingsState;
 
 public class TelemetryService {
     private static final TelemetryService INSTANCE = new TelemetryService();
@@ -21,4 +25,16 @@ public class TelemetryService {
     public static TelemetryMessageBuilder instance() {
         return INSTANCE.builder.get();
     }
+
+    public static void sendPackageUpdateEvent(PsiFile file, String recommendedVersion, String packageName, String actionName) {
+        var telemetryMsg = instance().action(actionName);
+        telemetryMsg.property("package", packageName);
+        telemetryMsg.property("version", recommendedVersion);
+        telemetryMsg.property(ApiService.TelemetryKeys.ECOSYSTEM.toString(), CAAnnotator.getPackageManager(file.getName()));
+        telemetryMsg.property(ApiService.TelemetryKeys.PLATFORM.toString(), System.getProperty("os.name"));
+        telemetryMsg.property(ApiService.TelemetryKeys.MANIFEST.toString(), file.getName());
+        telemetryMsg.property(ApiService.TelemetryKeys.RHDA_TOKEN.toString(), ApiSettingsState.getInstance().rhdaToken);
+        telemetryMsg.send();
+    }
+
 }


### PR DESCRIPTION
Added "component_analysis_recommendation_accepted" event to track recommendation acceptance for telemetry. 

Jira: [APPENG-2312](https://issues.redhat.com/browse/APPENG-2312)