### PR TITLE
fix: TC-1631

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -32,7 +32,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+
+import static org.jboss.tools.intellij.componentanalysis.CAService.iterateOverListOfStringDelimitedByCommaAndNewLineGetString;
 
 public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Map<Dependency, CAAnnotator.Result>> {
 
@@ -54,37 +57,55 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
                 && info.getDependencies() != null && !info.getDependencies().isEmpty()) {
             String path = info.getFile().getVirtualFile().getPath();
             Set<Dependency> dependencies = info.getDependencies().keySet();
-
             if (CAService.dependenciesModified(path, dependencies)) {
                 LOG.info("Generate vulnerability report");
                 Project project = info.getFile().getProject();
                 ApplicationManager.getApplication().executeOnPooledThread(() -> {
-                    boolean updated = CAService.performAnalysis(
-                            getPackageManager(info.getFile().getName()),
-                            info.getFile().getVirtualFile().getName(),
-                            info.getFile().getVirtualFile().getPath(),
-                            dependencies);
+                        boolean updated = CAService.performAnalysis(
+                                getPackageManager(info.getFile().getName()),
+                                info.getFile().getVirtualFile().getName(),
+                                info.getFile().getVirtualFile().getPath(),
+                                dependencies,
+                                info.getFile());
 
-                    ApplicationManager.getApplication().runReadAction(() -> {
-                        if (updated) {
-                            LOG.info("Refresh dependencies");
-                            try {
-                                DaemonCodeAnalyzer.getInstance(project).restart();
-                            } catch (AlreadyDisposedException ex) {
-                                LOG.warn("DaemonCodeAnalyzer disposed, invalidate cache: " + path, ex);
-                                CAService.deleteReports(path);
+                        ApplicationManager.getApplication().runReadAction(() -> {
+                            if (updated) {
+                                LOG.info("Refresh dependencies");
+                                try {
+                                    DaemonCodeAnalyzer.getInstance(project).restart(info.getFile());
+                                } catch (AlreadyDisposedException ex) {
+                                    LOG.warn("DaemonCodeAnalyzer disposed, invalidate cache: " + path, ex);
+                                    CAService.deleteReports(path);
+                                }
                             }
-                        }
+                        });
                     });
-                });
+
             }
 
             LOG.info("Get vulnerability report from cache");
             Map<Dependency, Map<VulnerabilitySource, DependencyReport>> reports = CAService.getReports(path);
-            return this.matchDependencies(info.getDependencies(), reports);
+            List<String> pairsOfDepsVulnsFromMap = CAService.getPairsOfDepsVulnsFromMap(reports);
+            LOG.info("Resolved Dependency->vuln pairs from cache");
+            LOG.info(iterateOverListOfStringDelimitedByCommaAndNewLineGetString(pairsOfDepsVulnsFromMap));
+            Map<Dependency, Result> dependencyResultMap = this.matchDependencies(info.getDependencies(), reports);
+            String debugString = reformatDependencyResultMapForDebugging(dependencyResultMap);
+            LOG.info("Pairs with offsets that are going to be applied=>");
+            LOG.info(debugString);
+            return dependencyResultMap;
         }
 
         return null;
+    }
+
+    private String reformatDependencyResultMapForDebugging(Map<Dependency, Result> dependencyResultMap) {
+        List<String> allPairsWithOffsetsInUi = dependencyResultMap.entrySet().stream().map(entry -> {
+            String dependency = entry.getKey().toPurl("maven").toString();
+            String stringOffSets = entry.getValue().elements.get(0).getTextRange().toString();
+            String dependencyVuln = entry.getValue().getReports().entrySet().stream().map(Map.Entry::getValue).map(dep -> dep.getRef().toString()).findFirst().get();
+            return String.format("%s==>%s==>%s", dependency, dependencyVuln, stringOffSets);
+        }).collect(Collectors.toList());
+        return iterateOverListOfStringDelimitedByCommaAndNewLineGetString(allPairsWithOffsetsInUi);
     }
 
     @Override
@@ -202,7 +223,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
 
     private Map<Dependency, Result> matchDependencies(Map<Dependency, List<PsiElement>> dependencies,
                                                       Map<Dependency, Map<VulnerabilitySource, DependencyReport>> reports) {
-        if (dependencies != null && !dependencies.isEmpty()
+         if (dependencies != null && !dependencies.isEmpty()
                 && reports != null && !reports.isEmpty()) {
             return dependencies.entrySet()
                     .parallelStream()

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -89,9 +89,13 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
             LOG.info("Resolved Dependency->vuln pairs from cache");
             LOG.info(iterateOverListOfStringDelimitedByCommaAndNewLineGetString(pairsOfDepsVulnsFromMap));
             Map<Dependency, Result> dependencyResultMap = this.matchDependencies(info.getDependencies(), reports);
-            String debugString = reformatDependencyResultMapForDebugging(dependencyResultMap);
-            LOG.info("Pairs with offsets that are going to be applied=>");
-            LOG.info(debugString);
+            String debugString;
+            if(Objects.nonNull(dependencyResultMap)) {
+                debugString = reformatDependencyResultMapForDebugging(dependencyResultMap);
+                LOG.info("Pairs with offsets that are going to be applied=>");
+                LOG.info(debugString);
+            }
+
             return dependencyResultMap;
         }
 

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAService.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAService.java
@@ -157,12 +157,14 @@ public final class CAService {
             } else {
                 getInstance().vulnerabilityCache.invalidate(filePath);
             }
-            allPairs = getPairsOfDepsVulnsFromMap(resultMap);
-            LOG.info("After - List of all dependencies and their purl from vulnerability dependency report " + iterateOverListOfStringDelimitedByCommaAndNewLineGetString(allPairs));
+            if(Objects.nonNull(resultMap)) {
+                allPairs = getPairsOfDepsVulnsFromMap(resultMap);
+                LOG.info("After - List of all dependencies and their purl from vulnerability dependency report " + iterateOverListOfStringDelimitedByCommaAndNewLineGetString(allPairs));
+            }
             LOG.info("List of dependencies in cache, before update" + System.lineSeparator() + getListOfDependencies(getInstance().dependencyCache.get(filePath, p -> Collections.emptySet())));
             getInstance().dependencyCache.put(filePath, dependencies);
             LOG.info("List of dependencies in cache, after after" + System.lineSeparator() + getListOfDependencies(dependencies));
-
+            return true;
 
 
         }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/Dependency.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/Dependency.java
@@ -11,6 +11,7 @@
 
 package org.jboss.tools.intellij.componentanalysis;
 
+import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 
 import java.util.Objects;
@@ -81,6 +82,14 @@ public class Dependency {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public String toPurl(String type) {
+        try {
+            return new PackageURL(type,this.namespace,this.name,this.version,null,null).toString();
+        } catch (MalformedPackageURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/golang/GoCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/golang/GoCAAnnotator.java
@@ -65,6 +65,7 @@ public class GoCAAnnotator extends CAAnnotator {
                         .filter(Objects::nonNull)
                         .filter(t -> t.getModuleVersion() != null)
                         .forEach(m -> resultMap.computeIfAbsent(createDependency(m), k -> new LinkedList<>()).add(m));
+
             }
 
             return resultMap;

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/gradle/GradleCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/gradle/GradleCAAnnotator.java
@@ -11,6 +11,7 @@
 
 package org.jboss.tools.intellij.componentanalysis.gradle;
 
+import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.xml.XmlComment;
@@ -47,7 +48,7 @@ public class GradleCAAnnotator extends CAAnnotator {
                         }
                     );
 
-            return resultMap;
+             return resultMap;
         }
 
         return Collections.emptyMap();


### PR DESCRIPTION
In case of Applying quick-fix, unless the user save the manifest really quick, there might be inconsistencies and incorrect data caused by the fact that the analysis is invoked with the saved file, which it still doesn't contain on disk the quick-fix version, hence this PR take the change from the cached data document in memory, create a temporary file, and invoke the analysis with it instead of with the original file ( which contains still the vulnerable version  before the quick-fix).

Fixes: https://issues.redhat.com/browse/TC-1631
