### PR TITLE
feat: support idea IJ Version 2024.1.x

### DIFF
--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IC-2022.1]
+        IJ: [IC-2022.3]
 
     steps:
     - uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
       - name: Build with Gradle
         run: >
           ./gradlew runPluginVerifier
-          -PideaVersion=IC-2022.1
+          -PideaVersion=IC-2022.3
           -Pgpr.username=${{ github.actor }}
           -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'gradle'
     - name: Grant execute permission for gradlew
@@ -34,10 +34,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'gradle'
     - name: Grant execute permission for gradlew
@@ -53,10 +53,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'gradle'
     - name: Grant execute permission for gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
    id "org.jetbrains.intellij" version "1.15.0"
 }
@@ -66,6 +65,9 @@ dependencies {
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     // https://mvnrepository.com/artifact/com.github.package-url/packageurl-java
     implementation group: 'com.github.package-url', name: 'packageurl-java', version: '1.4.1'
+    // https://mvnrepository.com/artifact/commons-io/commons-io
+    implementation group: 'commons-io', name: 'commons-io', version: '2.16.1'
+
 
 
     testImplementation('junit:junit:4.13.1')

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ intellij {
     version = ideaVersion //for a full list of IntelliJ IDEA releases please see https://www.jetbrains.com/intellij-repository/releases
     pluginName = 'org.jboss.tools.intellij.analytics'
     plugins = ['com.redhat.devtools.intellij.telemetry:1.1.0.52',
-               "org.jetbrains.plugins.go:221.5080.9",
-               "Docker:221.5080.9"]
+               "org.jetbrains.plugins.go:223.7571.182",
+               "Docker:223.7571.175"]
     updateSinceUntilBuild = false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-ideaVersion = 2022.1
+ideaVersion = 2022.3
 projectVersion=1.1.0-SNAPSHOT
 jetBrainsToken=invalid
 jetBrainsChannel=stable

--- a/src/main/java/org/jboss/tools/intellij/image/ImageReportAction.java
+++ b/src/main/java/org/jboss/tools/intellij/image/ImageReportAction.java
@@ -12,13 +12,15 @@
 package org.jboss.tools.intellij.image;
 
 import com.intellij.docker.dockerFile.DockerFileType;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.actionSystem.*;
 import org.jetbrains.annotations.NotNull;
 
 public class ImageReportAction extends AnAction {
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
+    }
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent event) {

--- a/src/main/java/org/jboss/tools/intellij/stackanalysis/SaAction.java
+++ b/src/main/java/org/jboss/tools/intellij/stackanalysis/SaAction.java
@@ -15,6 +15,7 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -42,6 +43,11 @@ public class SaAction extends AnAction {
 
     public SaAction() {
 
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+        return ActionUpdateThread.EDT;
     }
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -413,7 +413,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="211.0"/>
+    <idea-version since-build="223.0"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->


### PR DESCRIPTION
This PR is due to a new error raised in 2024.1.x for `AnAction` Actions in Intelli-J plugin SDK framework:

the IJ version 2024.1.x on latest build brutally deprecated the OLD_EDT ( Old Event Dispatcher Thread)  Action update Thread, with an exception ( No warning to replace it ASAP in logs, but error exception  that stops the plugin from being loaded and function properly), plugins that has actions of kind `AnAction` must explicitly choose in code for each action, whether they use BGT( Background Thread) or EDT thread for update actions  ( the plugin has two actions - Stack Analysis action for invoking analysis and getting HTML report and Image Analysis for invoking the batch analysis on Dockerfile' Base Image ) . 
This PR contains the needed changes to support this change - After that the error is gone.

But this one requires regression over go manifests ( in ultimate editions of IntelliJ) and Dockerfile base image scanning...
And also need to adjust the  workflows accordingly to this new version  bump of the Intelli-J framework version.

In addition, since the action code for generating the  stack analysis HTML Report was changed, there is a need to do regressions tests on HTML report generation.