### PR TITLE
build: bump actions to latest versions

### DIFF
--- a/.github/workflows/IJ-latest.yml
+++ b/.github/workflows/IJ-latest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -30,7 +30,7 @@ jobs:
           -PideaVersion=LATEST-EAP-SNAPSHOT
           -Pgpr.username=${{ github.actor }}
           -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-reports

--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -17,7 +17,7 @@ jobs:
         IJ: [IC-2022.3]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -55,7 +55,7 @@ jobs:
           -Pgpr.username=${{ github.actor }}
           -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
       - name: Upload report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: verifier-report

--- a/.github/workflows/IJ.yml
+++ b/.github/workflows/IJ.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        IJ: [IC-2022.3]
-
+        IJ:
+          - IC-2024.2
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -15,13 +15,14 @@ jobs:
     name: Build plugin
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Java 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'oracle'
+          cache: 'gradle'
 
       - name: Build plugin with Gradle
         uses: gradle/gradle-build-action@v2
@@ -32,7 +33,7 @@ jobs:
             -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload distribution archive as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: distributions
           path: ./build/distributions
@@ -45,17 +46,17 @@ jobs:
     if: github.repository == 'redhat-developer/intellij-dependency-analytics'
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: distributions
           path: ./distributions
 
       - name: Check for existing early-access release
         id: existing_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,7 +68,7 @@ jobs:
 
       - name: Delete early-access release if exists
         if: ${{ steps.existing_release.outputs.id }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -85,7 +86,7 @@ jobs:
 
       - name: Create new early-access release
         id: new_release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 .gradle
 out
 distributions
+bin


### PR DESCRIPTION
bump github actions due to upload-artifact deprecation [notice](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md).