### PR TITLE
fix: correct exhortApi.componentAnalysis call parameter

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
+++ b/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
@@ -92,7 +92,7 @@ public final class ApiService {
             CompletableFuture<AnalysisReport> componentReport;
             if ("go.mod".equals(manifestName) || "requirements.txt".equals(manifestName)) {
                 var manifestContent = Files.readAllBytes(Paths.get(manifestPath));
-                componentReport = exhortApi.componentAnalysis(manifestName, manifestContent);
+                componentReport = exhortApi.componentAnalysis(manifestPath, manifestContent);
             } else {
                 componentReport = exhortApi.componentAnalysis(manifestPath);
             }


### PR DESCRIPTION
fix: correct exhortApi.componentAnalysis call parameter

see more info in https://github.com/redhat-developer/intellij-dependency-analytics/issues/188

fix: https://github.com/redhat-developer/intellij-dependency-analytics/issues/188