### PR TITLE
fix: clarify IntelliJ Ultimate Edition requirement for Golang projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ vulnerability report.
 - For Maven projects, analyzing a `pom.xml` file, you must have the `mvn` binary in your IDE's `PATH` environment.
 - For Node projects, analyzing a `package.json` file, you must have one of the corresponding package manager `npm`, `pnpm` or `yarn`, `node` binaries in your IDE's `PATH`
   environment.
-- For Golang projects, analyzing a `go.mod` file, you must have the `go` binary in your IDE's `PATH` environment.
+- For Golang projects, analyzing a `go.mod` file, you must have the `go` binary in your IDE's `PATH` environment. Furthermore, Golang projects can only be analyzed with IntelliJ Ultimate Edition.
 - For Python projects, analyzing a `requirements.txt` file, you must have the `python3` and `pip3` binaries in your
   IDE's `PATH` environment.
 - For Gradle projects, analyzing a `build.gradle` file, you must have the `gradle` binary in your system's `PATH` environment.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
         <code>node</code> binaries in your IDE's <code>PATH</code> environment.
     </li>
     <li>For Golang projects, analyzing a <code>go.mod</code> file, you must have the <code>go</code> binary in your
-        IDE's <code>PATH</code> environment.
+        IDE's <code>PATH</code> environment. Furthermore, Golang projects can only be analyzed with IntelliJ Ultimate Edition.
     </li>
     <li>For Python projects, analyzing a <code>requirements.txt</code> file, you must have the <code>python3</code> and
         <code>pip3</code> binaries in your IDE's <code>PATH</code> environment.


### PR DESCRIPTION
fix: clarify IntelliJ Ultimate Edition requirement for Golang projects.

fixes: https://github.com/redhat-developer/intellij-dependency-analytics/issues/194