### PR TITLE
fix: ensure step Verify ZIP file exists only runs when there's actually something to verify

### DIFF
--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -145,6 +145,7 @@ jobs:
           echo "✅ Downloaded ZIP file successfully"
 
       - name: Verify ZIP file exists
+        if: steps.version_info.outputs.CHANNEL != 'none'
         run: |
           ls -la build/distributions/
           ZIP_FILE="build/distributions/intellij-dependency-analytics-${{ steps.version_info.outputs.VERSION }}.zip"


### PR DESCRIPTION
nightly are successfully published in https://plugins.jetbrains.com/plugin/12541-red-hat-dependency-analytics/versions/nightly, but step `Verify ZIP file exists` added in https://github.com/redhat-developer/intellij-dependency-analytics/pull/214 fails when there are no changes in a scheduled run