### PR TITLE
fix: return a new list to allow ExcludeManifestIntentionAction adds elements afterwards

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/ManifestExclusionManager.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/ManifestExclusionManager.java
@@ -23,6 +23,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -80,7 +81,7 @@ public class ManifestExclusionManager {
 
         ApiSettingsState settings = ApiSettingsState.getInstance();
         List<String> currentPatterns = parsePatterns(settings.manifestExclusionPatterns);
-        
+
         if (!currentPatterns.contains(relativePath)) {
             currentPatterns.add(relativePath);
             settings.manifestExclusionPatterns = String.join("\n", currentPatterns);
@@ -107,13 +108,13 @@ public class ManifestExclusionManager {
 
     private static List<String> parsePatterns(String patterns) {
         if (patterns == null || patterns.trim().isEmpty()) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
 
         return Arrays.stream(patterns.split("[\n\r]+"))
                 .map(String::trim)
                 .filter(pattern -> !pattern.isEmpty() && !pattern.startsWith("#"))
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private static boolean matchesAnyPattern(String path, List<String> patterns) {

--- a/src/test/java/org/jboss/tools/intellij/componentanalysis/ManifestExclusionManagerSimpleTest.java
+++ b/src/test/java/org/jboss/tools/intellij/componentanalysis/ManifestExclusionManagerSimpleTest.java
@@ -18,7 +18,8 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Simple tests for glob pattern matching behavior that don't require IntelliJ platform mocking.


### PR DESCRIPTION
fix: return a new list to allow `ExcludeManifestIntentionAction` adds elements afterwards

follow up https://github.com/redhat-developer/intellij-dependency-analytics/pull/200