### PR TITLE
fix: IntelliJ platform version range for plugin verification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,12 @@ val runIdeForUiTests by intellijPlatformTesting.runIde.registering {
 intellijPlatform {
     pluginVerification {
         ides {
-            recommended()
+            select {
+                types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
+                channels = listOf(ProductRelease.Channel.RELEASE) // Only stable releases
+                sinceBuild = "251" // From your minimum supported version
+                untilBuild = "252.*" // Up to current major version
+            }
         }
         freeArgs = listOf(
             "-mute",


### PR DESCRIPTION
fix: IntelliJ platform version range for plugin verification

there is a download issue for EAP version, let's only test against stable versions.
```

 Could not determine the dependencies of task ':verifyPlugin'.
> Could not resolve all files for configuration ':detachedConfiguration1'.
   > Could not find idea:ideaIC:253.25908.13.
     Searched in the following locations:
       - file:/home/runner/.m2/repository/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://repo.maven.apache.org/maven2/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://download.jetbrains.com/idea/ideaIC-253.25908.13.tar.gz
       - https://download.jetbrains.com/idea/253.25908.13/ideaIC-253.25908.13.tar.gz
       - https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/releases/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://cache-redirector.jetbrains.com/www.jetbrains.com/intellij-repository/snapshots/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://cache-redirector.jetbrains.com/intellij-dependencies/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://cache-redirector.jetbrains.com/plugins.jetbrains.com/maven/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://jitpack.io/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://maven.pkg.github.com/trustification/exhort-java-api/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
       - https://maven.pkg.github.com/guacsec/trustify-da-api-spec/idea/ideaIC/253.25908.13/ideaIC-253.25908.13.pom
     Required by:
         project :
```