### PR TITLE
fix: ensure plugin.xml explicitly declares a dependency on the JSON module which is required at runtime

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -481,6 +481,7 @@
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.lang</depends>
+    <depends>com.intellij.modules.json</depends>
     <depends>com.intellij.java</depends>
     <depends>org.jetbrains.idea.maven</depends>
     <depends>com.redhat.devtools.intellij.telemetry</depends>


### PR DESCRIPTION
This happens because JSON support has been extracted to a standalone plugin in newer IntelliJ versions (e.g., 2024.3 and later). We need to ensure that plugin.xml explicitly declares a dependency on the JSON module which is required at runtime.

fixes: https://github.com/redhat-developer/intellij-dependency-analytics/issues/231