### PR TITLE
feat: add license compatibility checking and mismatch detection

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -146,7 +146,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                         String name = getDependencyString(reportOptional.get().getRef().purl());
 
                         StringBuilder messageBuilder = new StringBuilder(name);
-                        StringBuilder tooltipBuilder = new StringBuilder("<html>").append("<p>").append(name).append("</p>");
+                        StringBuilder tooltipBuilder = new StringBuilder("<html>").append("<p>").append(escapeHtml(name)).append("</p>");
                         Map<VulnerabilitySource, DependencyReport> quickfixes = new HashMap<>();
 
                         reports.forEach((source, report) -> {
@@ -158,7 +158,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                                     messageBuilder.append(source.getProvider())
                                             .append(" vulnerability info: ");
                                     tooltipBuilder.append("<p>")
-                                            .append(source.getProvider())
+                                            .append(escapeHtml(source.getProvider()))
                                             .append(" vulnerability info:</p>");
                                 } else {
                                     messageBuilder.append(source.getSource())
@@ -166,9 +166,9 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                                             .append(source.getProvider())
                                             .append(") vulnerability info: ");
                                     tooltipBuilder.append("<p>")
-                                            .append(source.getSource())
+                                            .append(escapeHtml(source.getSource()))
                                             .append(" (")
-                                            .append(source.getProvider())
+                                            .append(escapeHtml(source.getProvider()))
                                             .append(") vulnerability info:</p>");
                                 }
 
@@ -184,7 +184,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                                     messageBuilder.append(", Highest severity: ")
                                             .append(severity);
                                     tooltipBuilder.append("<p>Highest severity: ")
-                                            .append(severity)
+                                            .append(escapeHtml(severity))
                                             .append("</p>");
                                 }
                             }
@@ -258,8 +258,8 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
         String message = "License mismatch: manifest declares \"" + manifestLicense
                 + "\" but LICENSE file contains \"" + fileLicense + "\"";
         String tooltip = "<html><p>License mismatch:</p>"
-                + "<p>Manifest declares: <b>" + manifestLicense + "</b></p>"
-                + "<p>LICENSE file contains: <b>" + fileLicense + "</b></p></html>";
+                + "<p>Manifest declares: <b>" + escapeHtml(manifestLicense) + "</b></p>"
+                + "<p>LICENSE file contains: <b>" + escapeHtml(fileLicense) + "</b></p></html>";
 
         AnnotationBuilder builder = holder
                 .newAnnotation(HighlightSeverity.ERROR, message)
@@ -425,9 +425,17 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
 
     private static String buildLicenseWarningTooltip(String depLicense, String projectLicense, String reason) {
         return "<p>License compatibility warning:</p>"
-                + "<p>Dependency license: " + depLicense + "</p>"
-                + "<p>Project license: " + projectLicense + "</p>"
-                + "<p>" + reason + "</p>";
+                + "<p>Dependency license: " + escapeHtml(depLicense) + "</p>"
+                + "<p>Project license: " + escapeHtml(projectLicense) + "</p>"
+                + "<p>" + escapeHtml(reason) + "</p>";
+    }
+
+    private static String escapeHtml(String text) {
+        if (text == null) return "";
+        return text.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;");
     }
 
     @NotNull
@@ -555,8 +563,8 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
     }
 
     public static class AnnotationData {
-        Map<Dependency, Result> results;
-        Map<Dependency, List<PsiElement>> allDependencies;
+        private final Map<Dependency, Result> results;
+        private final Map<Dependency, List<PsiElement>> allDependencies;
 
         public AnnotationData(Map<Dependency, Result> results, Map<Dependency, List<PsiElement>> allDependencies) {
             this.results = results;

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -39,6 +39,7 @@ import org.jboss.tools.intellij.settings.ApiSettingsState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -266,10 +267,12 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                 .tooltip(tooltip)
                 .range(licenseElement);
 
-        // Use the SPDX ID for replacement so the manifest matches what the client compares against
-        LicenseUpdateIntentionAction fix = createLicenseUpdateFix(licenseElement, fileSpdxId);
-        if (fix != null) {
-            builder.withFix(fix);
+        // Only offer quick-fix when a real SPDX ID is available
+        if (fileSpdxId != null) {
+            LicenseUpdateIntentionAction fix = createLicenseUpdateFix(licenseElement, fileSpdxId);
+            if (fix != null) {
+                builder.withFix(fix);
+            }
         }
 
         builder.create();
@@ -333,8 +336,8 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
         Map<Dependency, List<PsiElement>> noVersionMap = allDependencies.entrySet().stream()
                 .collect(Collectors.toMap(
                         e -> new Dependency(e.getKey(), false),
-                        Map.Entry::getValue,
-                        (o1, o2) -> o1));
+                        e -> new ArrayList<>(e.getValue()),
+                        (l1, l2) -> { l1.addAll(l2); return l1; }));
 
         for (IncompatibleDependency incompatible : licenseSummary.incompatibleDependencies()) {
             try {
@@ -363,10 +366,11 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                 String message = buildLicenseWarningMessage(licenseNames, projectLicenseName, reason);
                 String tooltip = buildLicenseWarningTooltip(licenseNames, projectLicenseName, reason);
 
+                String wrappedTooltip = "<html>" + tooltip + "</html>";
                 for (PsiElement element : elements) {
                     if (element != null) {
                         holder.newAnnotation(HighlightSeverity.WARNING, message)
-                                .tooltip(tooltip)
+                                .tooltip(wrappedTooltip)
                                 .range(element)
                                 .create();
                     }
@@ -392,12 +396,13 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
             return nameNode.asText();
         }
         // Fall back to SPDX ID
-        return extractSpdxId(licenseDetails);
+        String spdxId = extractSpdxId(licenseDetails);
+        return spdxId != null ? spdxId : "unknown";
     }
 
-    private static String extractSpdxId(@Nullable JsonNode licenseDetails) {
+    private static @Nullable String extractSpdxId(@Nullable JsonNode licenseDetails) {
         if (licenseDetails == null) {
-            return "unknown";
+            return null;
         }
         // Try identifiers array for the SPDX ID (e.g., "Apache-2.0", "MIT")
         JsonNode identifiers = licenseDetails.get("identifiers");
@@ -408,12 +413,12 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                 return idNode.asText();
             }
         }
-        // Fall back to name
-        JsonNode nameNode = licenseDetails.get("name");
-        if (nameNode != null && !nameNode.isNull() && !nameNode.asText().isBlank()) {
-            return nameNode.asText();
+        // Fall back to SPDX expression if available
+        JsonNode exprNode = licenseDetails.get("expression");
+        if (exprNode != null && !exprNode.isNull() && !exprNode.asText().isBlank()) {
+            return exprNode.asText();
         }
-        return "unknown";
+        return null;
     }
 
     private static String buildLicenseWarningMessage(String depLicense, String projectLicense, String reason) {

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -11,6 +11,8 @@
 
 package org.jboss.tools.intellij.componentanalysis;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.codeInsight.daemon.HighlightDisplayKey;
@@ -29,10 +31,16 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.serviceContainer.AlreadyDisposedException;
 import io.github.guacsec.trustifyda.api.v5.DependencyReport;
+import io.github.guacsec.trustifyda.api.v5.LicenseIdentifier;
+import io.github.guacsec.trustifyda.license.LicenseCheck.IncompatibleDependency;
+import io.github.guacsec.trustifyda.license.LicenseCheck.LicenseSummary;
+import io.github.guacsec.trustifyda.license.LicenseCheck.ProjectLicenseSummary;
+import org.jboss.tools.intellij.settings.ApiSettingsState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,7 +50,7 @@ import java.util.stream.Collectors;
 
 
 
-public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Map<Dependency, CAAnnotator.Result>> {
+public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CAAnnotator.AnnotationData> {
 
     private static final Logger LOG = Logger.getInstance(CAAnnotator.class);
 
@@ -63,7 +71,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
     }
 
     @Override
-    public @Nullable Map<Dependency, Result> doAnnotate(Info info) {
+    public @Nullable AnnotationData doAnnotate(Info info) {
         if (info != null && info.getFile() != null
                 && info.getDependencies() != null && !info.getDependencies().isEmpty()) {
             String path = info.getFile().getVirtualFile().getPath();
@@ -97,16 +105,35 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
             LOG.info("Get vulnerability report from cache");
             Map<Dependency, Map<VulnerabilitySource, DependencyReport>> reports = CAService.getReports(path);
             Map<Dependency, Result> dependencyResultMap = this.matchDependencies(info.getDependencies(), reports);
-            return dependencyResultMap;
+            return new AnnotationData(dependencyResultMap, info.getDependencies());
         }
 
         return null;
     }
 
     @Override
-    public void apply(@NotNull PsiFile file, Map<Dependency, Result> annotationResult, @NotNull AnnotationHolder holder) {
+    public void apply(@NotNull PsiFile file, AnnotationData annotationData, @NotNull AnnotationHolder holder) {
+        if (annotationData == null) {
+            return;
+        }
+
+        // Pre-build incompatible license info keyed by Dependency (without version)
+        Map<Dependency, String> licenseMessages = new HashMap<>();
+        Map<Dependency, String> licenseTooltips = new HashMap<>();
+        LicenseSummary licenseSummary = null;
+        if (ApiSettingsState.getInstance().licenseCheckEnabled) {
+            String path = file.getVirtualFile().getPath();
+            licenseSummary = CAService.getLicenseSummary(path);
+            if (licenseSummary != null) {
+                buildIncompatibleLicenseInfo(licenseSummary, licenseMessages, licenseTooltips);
+            }
+        }
+
         LOG.info("Annotate dependencies");
-        annotationResult.forEach((key, value) -> {
+        Set<Dependency> annotatedLicenseDeps = new HashSet<>();
+        Map<Dependency, Result> annotationResult = annotationData.getResults();
+        if (annotationResult != null) {
+            annotationResult.forEach((key, value) -> {
             if (value != null) {
                 Map<VulnerabilitySource, DependencyReport> reports = value.getReports();
                 List<PsiElement> elements = value.getElements();
@@ -167,6 +194,15 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
                             }
                         });
 
+                        // Merge license incompatibility info into the annotation
+                        Dependency noVersionKey = new Dependency(key, false);
+                        String licenseMsg = licenseMessages.get(noVersionKey);
+                        if (licenseMsg != null) {
+                            messageBuilder.append(System.lineSeparator()).append(licenseMsg);
+                            tooltipBuilder.append("<p/>").append(licenseTooltips.get(noVersionKey));
+                            annotatedLicenseDeps.add(noVersionKey);
+                        }
+
                         elements.forEach(e -> {
                             if (e != null) {
                                 if (!quickfixes.isEmpty() && this.isQuickFixApplicable(e)) {
@@ -195,11 +231,213 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
                 }
             }
         });
+        }
+
+        // License annotations for deps not already annotated above
+        if (licenseSummary != null) {
+            applyLicenseMismatchAnnotation(file, licenseSummary, holder);
+            applyIncompatibleDependencyAnnotations(annotationData.getAllDependencies(), licenseSummary, annotatedLicenseDeps, holder);
+        }
+    }
+
+    private void applyLicenseMismatchAnnotation(@NotNull PsiFile file, LicenseSummary licenseSummary, @NotNull AnnotationHolder holder) {
+        ProjectLicenseSummary projectLicense = licenseSummary.projectLicense();
+        if (projectLicense == null || !projectLicense.mismatch()) {
+            return;
+        }
+
+        PsiElement licenseElement = getLicenseFieldPsiElement(file);
+        if (licenseElement == null) {
+            return;
+        }
+
+        String manifestLicense = extractLicenseName(projectLicense.manifest());
+        String fileLicense = extractLicenseName(projectLicense.file());
+        String fileSpdxId = extractSpdxId(projectLicense.file());
+
+        String message = "License mismatch: manifest declares \"" + manifestLicense
+                + "\" but LICENSE file contains \"" + fileLicense + "\"";
+        String tooltip = "<html><p>License mismatch:</p>"
+                + "<p>Manifest declares: <b>" + manifestLicense + "</b></p>"
+                + "<p>LICENSE file contains: <b>" + fileLicense + "</b></p></html>";
+
+        AnnotationBuilder builder = holder
+                .newAnnotation(HighlightSeverity.ERROR, message)
+                .tooltip(tooltip)
+                .range(licenseElement);
+
+        // Use the SPDX ID for replacement so the manifest matches what the client compares against
+        LicenseUpdateIntentionAction fix = createLicenseUpdateFix(licenseElement, fileSpdxId);
+        if (fix != null) {
+            builder.withFix(fix);
+        }
+
+        builder.create();
+    }
+
+    private void buildIncompatibleLicenseInfo(
+            LicenseSummary licenseSummary,
+            Map<Dependency, String> messages,
+            Map<Dependency, String> tooltips) {
+        if (licenseSummary.incompatibleDependencies() == null || licenseSummary.incompatibleDependencies().isEmpty()) {
+            return;
+        }
+
+        ProjectLicenseSummary projectLicense = licenseSummary.projectLicense();
+        String projectLicenseName = projectLicense != null
+                ? extractLicenseName(projectLicense.manifest() != null ? projectLicense.manifest() : projectLicense.file())
+                : "unknown";
+
+        for (IncompatibleDependency incompatible : licenseSummary.incompatibleDependencies()) {
+            try {
+                PackageURL purl = new PackageURL(incompatible.purl());
+                Dependency dep = new Dependency(purl, false);
+
+                String licenseNames = incompatible.licenses() != null
+                        ? incompatible.licenses().stream()
+                            .map(LicenseIdentifier::getName)
+                            .collect(Collectors.joining(", "))
+                        : "unknown";
+
+                String reason = incompatible.reason() != null
+                        ? incompatible.reason()
+                        : "This dependency may require relicensing if distributed.";
+
+                messages.put(dep, buildLicenseWarningMessage(licenseNames, projectLicenseName, reason));
+                tooltips.put(dep, buildLicenseWarningTooltip(licenseNames, projectLicenseName, reason));
+
+            } catch (MalformedPackageURLException ex) {
+                LOG.warn("Failed to parse PURL from incompatible dependency: " + incompatible.purl(), ex);
+            }
+        }
+    }
+
+    private void applyIncompatibleDependencyAnnotations(
+            Map<Dependency, List<PsiElement>> allDependencies,
+            LicenseSummary licenseSummary,
+            Set<Dependency> alreadyAnnotated,
+            @NotNull AnnotationHolder holder) {
+        if (licenseSummary.incompatibleDependencies() == null || licenseSummary.incompatibleDependencies().isEmpty()) {
+            return;
+        }
+        if (allDependencies == null || allDependencies.isEmpty()) {
+            return;
+        }
+
+        ProjectLicenseSummary projectLicense = licenseSummary.projectLicense();
+        String projectLicenseName = projectLicense != null
+                ? extractLicenseName(projectLicense.manifest() != null ? projectLicense.manifest() : projectLicense.file())
+                : "unknown";
+
+        // Build a lookup map without version for matching
+        Map<Dependency, List<PsiElement>> noVersionMap = allDependencies.entrySet().stream()
+                .collect(Collectors.toMap(
+                        e -> new Dependency(e.getKey(), false),
+                        Map.Entry::getValue,
+                        (o1, o2) -> o1));
+
+        for (IncompatibleDependency incompatible : licenseSummary.incompatibleDependencies()) {
+            try {
+                PackageURL purl = new PackageURL(incompatible.purl());
+                Dependency dep = new Dependency(purl, false);
+
+                // Skip deps already annotated with merged license info
+                if (alreadyAnnotated.contains(dep)) {
+                    continue;
+                }
+
+                List<PsiElement> elements = noVersionMap.get(dep);
+                if (elements == null || elements.isEmpty()) {
+                    continue;
+                }
+
+                String licenseNames = incompatible.licenses() != null
+                        ? incompatible.licenses().stream()
+                            .map(LicenseIdentifier::getName)
+                            .collect(Collectors.joining(", "))
+                        : "unknown";
+
+                String reason = incompatible.reason() != null
+                        ? incompatible.reason()
+                        : "This dependency may require relicensing if distributed.";
+                String message = buildLicenseWarningMessage(licenseNames, projectLicenseName, reason);
+                String tooltip = buildLicenseWarningTooltip(licenseNames, projectLicenseName, reason);
+
+                for (PsiElement element : elements) {
+                    if (element != null) {
+                        holder.newAnnotation(HighlightSeverity.WARNING, message)
+                                .tooltip(tooltip)
+                                .range(element)
+                                .create();
+                    }
+                }
+            } catch (MalformedPackageURLException ex) {
+                LOG.warn("Failed to parse PURL from incompatible dependency: " + incompatible.purl(), ex);
+            }
+        }
+    }
+
+    private static String extractLicenseName(@Nullable JsonNode licenseDetails) {
+        if (licenseDetails == null) {
+            return "unknown";
+        }
+        // Try "expression" first (SPDX expressions like "MIT OR Apache-2.0")
+        JsonNode exprNode = licenseDetails.get("expression");
+        if (exprNode != null && !exprNode.isNull() && !exprNode.asText().isBlank()) {
+            return exprNode.asText();
+        }
+        // Try "name" field for human-readable display
+        JsonNode nameNode = licenseDetails.get("name");
+        if (nameNode != null && !nameNode.isNull() && !nameNode.asText().isBlank()) {
+            return nameNode.asText();
+        }
+        // Fall back to SPDX ID
+        return extractSpdxId(licenseDetails);
+    }
+
+    private static String extractSpdxId(@Nullable JsonNode licenseDetails) {
+        if (licenseDetails == null) {
+            return "unknown";
+        }
+        // Try identifiers array for the SPDX ID (e.g., "Apache-2.0", "MIT")
+        JsonNode identifiers = licenseDetails.get("identifiers");
+        if (identifiers != null && identifiers.isArray() && !identifiers.isEmpty()) {
+            JsonNode first = identifiers.get(0);
+            JsonNode idNode = first.get("id");
+            if (idNode != null && !idNode.isNull() && !idNode.asText().isBlank()) {
+                return idNode.asText();
+            }
+        }
+        // Fall back to name
+        JsonNode nameNode = licenseDetails.get("name");
+        if (nameNode != null && !nameNode.isNull() && !nameNode.asText().isBlank()) {
+            return nameNode.asText();
+        }
+        return "unknown";
+    }
+
+    private static String buildLicenseWarningMessage(String depLicense, String projectLicense, String reason) {
+        return "License compatibility warning: "
+                + "Dependency license: " + depLicense
+                + ", Project license: " + projectLicense
+                + ". " + reason;
+    }
+
+    private static String buildLicenseWarningTooltip(String depLicense, String projectLicense, String reason) {
+        return "<p>License compatibility warning:</p>"
+                + "<p>Dependency license: " + depLicense + "</p>"
+                + "<p>Project license: " + projectLicense + "</p>"
+                + "<p>" + reason + "</p>";
     }
 
     @NotNull
     private HighlightSeverity getHighlightSeverity(DependencyReport report, @NotNull PsiElement context) {
-        // Get the configured severity from the inspection settings
+        // Recommendation-only (no vulnerabilities) should always use WEAK_WARNING
+        if (CAIntentionAction.thereAreNoIssues(report) && CAIntentionAction.thereIsRecommendation(report)) {
+            return HighlightSeverity.WEAK_WARNING;
+        }
+
+        // For actual vulnerabilities, use the configured severity from the inspection settings
         final InspectionProfileEntry inspection = this.getInspection(context, this.getInspectionShortName());
         if (inspection != null) {
             final InspectionProfile profile = InspectionProjectProfileManager.getInstance(context.getProject()).getCurrentProfile();
@@ -210,12 +448,7 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
             }
         }
 
-        // Fallback to original logic if inspection settings can't be determined
-        if(CAIntentionAction.thereAreNoIssues(report) && CAIntentionAction.thereIsRecommendation(report)) {
-            return HighlightSeverity.WEAK_WARNING;
-        } else {
-            return HighlightSeverity.ERROR;
-        }
+        return HighlightSeverity.ERROR;
     }
 
     abstract protected String getInspectionShortName();
@@ -225,6 +458,10 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
     abstract protected CAIntentionAction createQuickFix(PsiElement element, VulnerabilitySource source, DependencyReport report);
     abstract protected CAUpdateManifestIntentionAction patchManifest(PsiElement element, DependencyReport report);
     abstract protected boolean isQuickFixApplicable(PsiElement element);
+
+    abstract protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file);
+
+    abstract protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense);
 
     private Map<Dependency, Result> matchDependencies(Map<Dependency, List<PsiElement>> dependencies,
                                                       Map<Dependency, Map<VulnerabilitySource, DependencyReport>> reports) {
@@ -314,6 +551,24 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, Ma
 
         public Map<VulnerabilitySource, DependencyReport> getReports() {
             return reports;
+        }
+    }
+
+    public static class AnnotationData {
+        Map<Dependency, Result> results;
+        Map<Dependency, List<PsiElement>> allDependencies;
+
+        public AnnotationData(Map<Dependency, Result> results, Map<Dependency, List<PsiElement>> allDependencies) {
+            this.results = results;
+            this.allDependencies = allDependencies;
+        }
+
+        public Map<Dependency, Result> getResults() {
+            return results;
+        }
+
+        public Map<Dependency, List<PsiElement>> getAllDependencies() {
+            return allDependencies;
         }
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAService.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAService.java
@@ -72,6 +72,12 @@ public final class CAService {
         getInstance().dependencyCache.invalidate(filePath);
     }
 
+    public static void invalidateAllCaches() {
+        getInstance().vulnerabilityCache.invalidateAll();
+        getInstance().licenseCache.invalidateAll();
+        getInstance().dependencyCache.invalidateAll();
+    }
+
     public static LicenseSummary getLicenseSummary(String filePath) {
         return getInstance().licenseCache.getIfPresent(filePath);
     }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAService.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAService.java
@@ -23,10 +23,12 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
+import io.github.guacsec.trustifyda.ComponentAnalysisResult;
 import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
 import io.github.guacsec.trustifyda.api.v5.DependencyReport;
 import io.github.guacsec.trustifyda.api.v5.ProviderReport;
 import io.github.guacsec.trustifyda.api.v5.Source;
+import io.github.guacsec.trustifyda.license.LicenseCheck.LicenseSummary;
 import org.jboss.tools.intellij.exhort.ApiService;
 
 import java.util.Collections;
@@ -56,12 +58,22 @@ public final class CAService {
             .maximumSize(100)
             .build();
 
+    private final Cache<String, LicenseSummary> licenseCache = Caffeine.newBuilder()
+            .maximumSize(100)
+            .build();
+
     public static Map<Dependency, Map<VulnerabilitySource, DependencyReport>> getReports(String filePath) {
         return Collections.unmodifiableMap(getInstance().vulnerabilityCache.get(filePath, p -> Collections.emptyMap()));
     }
 
     public static void deleteReports(String filePath) {
         getInstance().vulnerabilityCache.invalidate(filePath);
+        getInstance().licenseCache.invalidate(filePath);
+        getInstance().dependencyCache.invalidate(filePath);
+    }
+
+    public static LicenseSummary getLicenseSummary(String filePath) {
+        return getInstance().licenseCache.getIfPresent(filePath);
     }
 
     public static boolean dependenciesModified(String filePath, Set<Dependency> dependencies) {
@@ -90,9 +102,21 @@ public final class CAService {
                 );
             }
 
-            AnalysisReport report = apiService.getComponentAnalysis(packageManager, fileName, filePath);
-            if (report == null) {
+            ComponentAnalysisResult analysisResult = apiService.getComponentAnalysis(packageManager, fileName, filePath);
+            if (analysisResult == null) {
                 throw new RuntimeException("Failed to perform component analysis, result is invalid.");
+            }
+            AnalysisReport report = analysisResult.report();
+            if (report == null) {
+                throw new RuntimeException("Failed to perform component analysis, report is invalid.");
+            }
+
+            // Cache license summary
+            LicenseSummary licenseSummary = analysisResult.licenseSummary();
+            if (licenseSummary != null) {
+                getInstance().licenseCache.put(filePath, licenseSummary);
+            } else {
+                getInstance().licenseCache.invalidate(filePath);
             }
 
             Map<Dependency, Map<VulnerabilitySource, DependencyReport>> resultMap = new ConcurrentHashMap<>();

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/LicenseUpdateIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/LicenseUpdateIntentionAction.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.intellij.componentanalysis;
+
+import com.intellij.codeInsight.intention.FileModifier;
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.BiConsumer;
+
+public class LicenseUpdateIntentionAction implements IntentionAction {
+
+    private final @FileModifier.SafeFieldForPreview PsiElement element;
+    private final String newLicense;
+    private final BiConsumer<PsiElement, String> replacer;
+
+    public LicenseUpdateIntentionAction(PsiElement element, String newLicense, BiConsumer<PsiElement, String> replacer) {
+        this.element = element;
+        this.newLicense = newLicense;
+        this.replacer = replacer;
+    }
+
+    @Override
+    public @IntentionName @NotNull String getText() {
+        return "Update manifest license to \"" + newLicense + "\" (from LICENSE file)";
+    }
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return "RHDA";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        return element != null && element.isValid();
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        replacer.accept(element, newLicense);
+
+        // Invalidate caches so the next annotator pass triggers a fresh API call
+        if (file != null && file.getVirtualFile() != null) {
+            CAService.deleteReports(file.getVirtualFile().getPath());
+        }
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return true;
+    }
+
+    @Override
+    public @Nullable FileModifier getFileModifierForPreview(@NotNull PsiFile target) {
+        PsiElement copy = PsiTreeUtil.findSameElementInCopy(this.element, target);
+        return new LicenseUpdateIntentionAction(copy, this.newLicense, this.replacer);
+    }
+}

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/cargo/CargoCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/cargo/CargoCAAnnotator.java
@@ -18,7 +18,9 @@ import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
 import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.Dependency;
+import org.jboss.tools.intellij.componentanalysis.LicenseUpdateIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jetbrains.annotations.Nullable;
 import com.intellij.psi.PsiComment;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -318,6 +320,48 @@ public class CargoCAAnnotator extends CAAnnotator {
         }
 
         return UNRESOLVED_VERSION;
+    }
+
+    @Override
+    protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file) {
+        // Find [package] table, then "license" key-value
+        List<TomlTable> tables = PsiTreeUtil.getChildrenOfTypeAsList(file, TomlTable.class);
+        for (TomlTable table : tables) {
+            TomlTableHeader header = table.getHeader();
+            TomlKey key = header.getKey();
+            if (key == null) continue;
+            List<TomlKeySegment> segments = key.getSegments();
+            if (segments.size() == 1 && "package".equals(segments.get(0).getName())) {
+                List<TomlKeyValue> keyValues = PsiTreeUtil.getChildrenOfTypeAsList(table, TomlKeyValue.class);
+                for (TomlKeyValue kv : keyValues) {
+                    if ("license".equals(normalizeKeyName(kv.getKey().getText()))) {
+                        TomlValue value = kv.getValue();
+                        if (value instanceof TomlLiteral) {
+                            return value;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense) {
+        if (!(element instanceof TomlLiteral)) {
+            return null;
+        }
+        return new LicenseUpdateIntentionAction(element, newLicense, (el, license) -> {
+            // Replace the TOML literal text (including quotes), matching CargoCAIntentionAction pattern
+            Document doc = PsiDocumentManager.getInstance(el.getProject())
+                    .getDocument(el.getContainingFile());
+            if (doc != null) {
+                int start = el.getTextRange().getStartOffset();
+                int end = el.getTextRange().getEndOffset();
+                doc.replaceString(start, end, "\"" + license + "\"");
+                PsiDocumentManager.getInstance(el.getProject()).commitDocument(doc);
+            }
+        });
     }
 
     private void parseFlatDependencies(TomlTable table, Set<String> ignoredDeps, Map<Dependency, List<PsiElement>> resultMap) {

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/golang/GoCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/golang/GoCAAnnotator.java
@@ -18,7 +18,9 @@ import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
 import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.Dependency;
+import org.jboss.tools.intellij.componentanalysis.LicenseUpdateIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -140,6 +142,17 @@ public class GoCAAnnotator extends CAAnnotator {
     @Override
     protected boolean isQuickFixApplicable(PsiElement element) {
         return element != null && element.getContainingFile().getName().equals("go.mod");
+    }
+
+    // go.mod has no license field; license detection relies on the LICENSE file
+    @Override
+    protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file) {
+        return null;
+    }
+
+    @Override
+    protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense) {
+        return null;
     }
 
     private PsiElement findElementAtLine(PsiFile file, int lineNumber) {

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/gradle/GradleCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/gradle/GradleCAAnnotator.java
@@ -18,7 +18,9 @@ import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
 import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.Dependency;
+import org.jboss.tools.intellij.componentanalysis.LicenseUpdateIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jetbrains.annotations.Nullable;
 import org.jboss.tools.intellij.componentanalysis.gradle.build.psi.Artifact;
 
 import java.util.Arrays;
@@ -74,5 +76,16 @@ public class GradleCAAnnotator extends CAAnnotator {
     @Override
     protected boolean isQuickFixApplicable(PsiElement element) {
         return true;
+    }
+
+    // Gradle has no standardized license field location; license detection relies on the LICENSE file
+    @Override
+    protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file) {
+        return null;
+    }
+
+    @Override
+    protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense) {
+        return null;
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAAnnotator.java
@@ -22,7 +22,9 @@ import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
 import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.Dependency;
+import org.jboss.tools.intellij.componentanalysis.LicenseUpdateIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jetbrains.annotations.Nullable;
 
 
 import java.util.Arrays;
@@ -145,5 +147,33 @@ public class MavenCAAnnotator extends CAAnnotator {
                     .anyMatch(c -> c instanceof XmlText);
         }
         return false;
+    }
+
+    @Override
+    protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file) {
+        // Find <project><licenses><license><name> text element
+        return Arrays.stream(file.getChildren())
+                .filter(e -> e instanceof XmlDocument)
+                .flatMap(e -> Arrays.stream(e.getChildren()))
+                .filter(e -> e instanceof XmlTag && "project".equals(((XmlTag) e).getName()))
+                .flatMap(e -> Arrays.stream(e.getChildren()))
+                .filter(e -> e instanceof XmlTag && "licenses".equals(((XmlTag) e).getName()))
+                .flatMap(e -> Arrays.stream(e.getChildren()))
+                .filter(e -> e instanceof XmlTag && "license".equals(((XmlTag) e).getName()))
+                .flatMap(e -> Arrays.stream(e.getChildren()))
+                .filter(e -> e instanceof XmlTag && "name".equals(((XmlTag) e).getName()))
+                .flatMap(e -> Arrays.stream(((XmlTag) e).getValue().getChildren()))
+                .filter(e -> e instanceof XmlText)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense) {
+        if (!(element instanceof XmlText)) {
+            return null;
+        }
+        return new LicenseUpdateIntentionAction(element, newLicense, (el, license) ->
+                ((XmlText) el).setValue(license));
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/npm/NpmCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/npm/NpmCAAnnotator.java
@@ -11,6 +11,8 @@
 
 package org.jboss.tools.intellij.componentanalysis.npm;
 
+import com.intellij.json.psi.JsonElementGenerator;
+import com.intellij.json.psi.JsonObject;
 import com.intellij.json.psi.JsonProperty;
 import com.intellij.json.psi.JsonStringLiteral;
 import com.intellij.psi.PsiElement;
@@ -20,8 +22,11 @@ import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
 import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.Dependency;
+import org.jboss.tools.intellij.componentanalysis.LicenseUpdateIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -52,5 +57,28 @@ public class NpmCAAnnotator extends CAAnnotator {
     @Override
     protected boolean isQuickFixApplicable(PsiElement element) {
         return element instanceof JsonProperty && ((JsonProperty) element).getValue() instanceof JsonStringLiteral;
+    }
+
+    @Override
+    protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file) {
+        return Arrays.stream(file.getChildren())
+                .filter(e -> e instanceof JsonObject)
+                .flatMap(e -> Arrays.stream(e.getChildren()))
+                .filter(e -> e instanceof JsonProperty && "license".equals(((JsonProperty) e).getName()))
+                .map(e -> ((JsonProperty) e).getValue())
+                .filter(v -> v instanceof JsonStringLiteral)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense) {
+        if (!(element instanceof JsonStringLiteral)) {
+            return null;
+        }
+        return new LicenseUpdateIntentionAction(element, newLicense, (el, license) -> {
+            JsonStringLiteral newValue = new JsonElementGenerator(el.getProject()).createStringLiteral(license);
+            el.replace(newValue);
+        });
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/pypi/PipCAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/pypi/PipCAAnnotator.java
@@ -18,7 +18,9 @@ import org.jboss.tools.intellij.componentanalysis.CAAnnotator;
 import org.jboss.tools.intellij.componentanalysis.CAIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.CAUpdateManifestIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.Dependency;
+import org.jboss.tools.intellij.componentanalysis.LicenseUpdateIntentionAction;
 import org.jboss.tools.intellij.componentanalysis.VulnerabilitySource;
+import org.jetbrains.annotations.Nullable;
 import org.jboss.tools.intellij.componentanalysis.pypi.requirements.psi.NameReq;
 import org.jboss.tools.intellij.componentanalysis.pypi.requirements.psi.NameReqComment;
 
@@ -81,5 +83,16 @@ public class PipCAAnnotator extends CAAnnotator {
     @Override
     protected boolean isQuickFixApplicable(PsiElement element) {
         return element instanceof NameReq && ((NameReq) element).getVersionspec() != null;
+    }
+
+    // requirements.txt has no license field; license detection relies on the LICENSE file
+    @Override
+    protected @Nullable PsiElement getLicenseFieldPsiElement(PsiFile file) {
+        return null;
+    }
+
+    @Override
+    protected @Nullable LicenseUpdateIntentionAction createLicenseUpdateFix(PsiElement element, String newLicense) {
+        return null;
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
+++ b/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
@@ -20,7 +20,7 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.util.net.ProxyConfiguration;
 import com.intellij.util.net.ProxySettings;
 import io.github.guacsec.trustifyda.Api;
-import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
+import io.github.guacsec.trustifyda.ComponentAnalysisResult;
 import io.github.guacsec.trustifyda.impl.ExhortApi;
 import org.jboss.tools.intellij.settings.ApiSettingsState;
 import org.jboss.tools.intellij.settings.MavenSettingsUtil;
@@ -28,7 +28,6 @@ import org.jboss.tools.intellij.settings.MavenSettingsUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -88,7 +87,7 @@ public final class ApiService {
         }
     }
 
-    public AnalysisReport getComponentAnalysis(final String packageManager, final String manifestName, final String manifestPath) {
+    public ComponentAnalysisResult getComponentAnalysis(final String packageManager, final String manifestName, final String manifestPath) {
         var telemetryMsg = TelemetryService.instance().action("component-analysis");
         telemetryMsg.property(TelemetryKeys.ECOSYSTEM.toString(), packageManager);
         telemetryMsg.property(TelemetryKeys.PLATFORM.toString(), System.getProperty("os.name"));
@@ -97,16 +96,11 @@ public final class ApiService {
 
         try {
             setRequestProperties(manifestName);
-            CompletableFuture<AnalysisReport> componentReport;
-            if ("go.mod".equals(manifestName) || "requirements.txt".equals(manifestName)) {
-                var manifestContent = Files.readAllBytes(Paths.get(manifestPath));
-                componentReport = exhortApi.componentAnalysis(manifestPath, manifestContent);
-            } else {
-                componentReport = exhortApi.componentAnalysis(manifestPath);
-            }
-            AnalysisReport report = componentReport.get();
+            CompletableFuture<ComponentAnalysisResult> componentReport =
+                    exhortApi.componentAnalysisWithLicense(manifestPath);
+            ComponentAnalysisResult result = componentReport.get();
             telemetryMsg.send();
-            return report;
+            return result;
         } catch (IOException | InterruptedException | ExecutionException ex) {
             telemetryMsg.error(ex);
             telemetryMsg.send();
@@ -266,6 +260,12 @@ public final class ApiService {
         if (!"go.mod".equals(manifestName) && !"requirements.txt".equals(manifestName)) {
             System.clearProperty("MATCH_MANIFEST_VERSIONS");
         }
+        if (settings.licenseCheckEnabled) {
+            System.setProperty("TRUSTIFY_DA_LICENSE_CHECK", "true");
+        } else {
+            System.setProperty("TRUSTIFY_DA_LICENSE_CHECK", "false");
+        }
+
         Optional<String> proxyUrlOpt = getProxyUrl();
         if (proxyUrlOpt.isPresent()) {
             System.setProperty("TRUSTIFY_DA_PROXY_URL", proxyUrlOpt.get());
@@ -286,9 +286,7 @@ public final class ApiService {
         // This API only works in 2024.2+ versions.
         ProxyConfiguration proxyConfiguration = ProxySettings.getInstance().getProxyConfiguration();
 
-        if (proxyConfiguration instanceof ProxyConfiguration.StaticProxyConfiguration) {
-            ProxyConfiguration.StaticProxyConfiguration staticProxyConfiguration =
-                    (ProxyConfiguration.StaticProxyConfiguration) proxyConfiguration;
+        if (proxyConfiguration instanceof ProxyConfiguration.StaticProxyConfiguration staticProxyConfiguration) {
 
             String protocol = staticProxyConfiguration.getProtocol().toString().toLowerCase(); // e.g., "http" or "socks"
             String host = staticProxyConfiguration.getHost();

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsComponent.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsComponent.java
@@ -84,6 +84,8 @@ public class ApiSettingsComponent {
     private final static String reportFilePathLabel = "<html>Reports > Save Directory: <b>Path</b>"
             + "<br>Specifies directory where stack analytics reports will be saved permanently."
             + "<br>Leave empty to use temporary files only.</html>";
+    private final static String licenseCheckEnabledLabel = "<html>Component Analysis > License Check"
+            + "<br>Enables license compatibility checking and notifications for incompatible dependencies.</html>";
 
     private final JPanel mainPanel;
 
@@ -116,6 +118,7 @@ public class ApiSettingsComponent {
     private final JBTextArea manifestExclusionPatternsText;
     private final JBScrollPane manifestExclusionPatternsScrollPane;
     private final TextFieldWithBrowseButton reportFilePathText;
+    private final JBCheckBox licenseCheckEnabledCheck;
 
 
     public ApiSettingsComponent() {
@@ -252,6 +255,8 @@ public class ApiSettingsComponent {
 
         imagePlatformText = new JBTextField();
 
+        licenseCheckEnabledCheck = new JBCheckBox("Enable license compatibility checking");
+
         manifestExclusionPatternsText = new JBTextArea();
         manifestExclusionPatternsText.setRows(5);
         manifestExclusionPatternsText.setColumns(50);
@@ -317,6 +322,9 @@ public class ApiSettingsComponent {
                 .addLabeledComponent(new JBLabel(podmanPathLabel), podmanPathText, 1, true)
                 .addVerticalGap(10)
                 .addLabeledComponent(new JBLabel(imagePlatformLabel), imagePlatformText, 1, true)
+                .addSeparator(10)
+                .addVerticalGap(10)
+                .addLabeledComponent(new JBLabel(licenseCheckEnabledLabel), licenseCheckEnabledCheck, 1, true)
                 .addSeparator(10)
                 .addVerticalGap(10)
                 .addLabeledComponent(new JBLabel(manifestExclusionPatternsLabel), manifestExclusionPatternsScrollPane, 1, true)
@@ -560,5 +568,13 @@ public class ApiSettingsComponent {
 
     public void setReportFilePathText(@NotNull String text) {
         reportFilePathText.setText(text);
+    }
+
+    public boolean getLicenseCheckEnabledCheck() {
+        return licenseCheckEnabledCheck.isSelected();
+    }
+
+    public void setLicenseCheckEnabledCheck(boolean selected) {
+        licenseCheckEnabledCheck.setSelected(selected);
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsConfigurable.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsConfigurable.java
@@ -71,6 +71,7 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         modified |= !Objects.equals(settingsComponent.getCargoPathText(), settings.cargoPath);
         modified |= !settingsComponent.getManifestExclusionPatternsText().equals(settings.manifestExclusionPatterns);
         modified |= !settingsComponent.getReportFilePathText().equals(settings.reportFilePath);
+        modified |= settingsComponent.getLicenseCheckEnabledCheck() != settings.licenseCheckEnabled;
         return modified;
     }
 
@@ -104,14 +105,18 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         settings.reportFilePath = settingsComponent.getReportFilePathText();
         settings.cargoPath = settingsComponent.getCargoPathText();
 
+        // Check if license check setting changed
+        boolean licenseCheckChanged = settingsComponent.getLicenseCheckEnabledCheck() != settings.licenseCheckEnabled;
+        settings.licenseCheckEnabled = settingsComponent.getLicenseCheckEnabledCheck();
+
         // Check if exclusion patterns changed
         String oldPatterns = settings.manifestExclusionPatterns;
         String newPatterns = settingsComponent.getManifestExclusionPatternsText();
         boolean patternsChanged = !Objects.equals(oldPatterns, newPatterns);
         settings.manifestExclusionPatterns = newPatterns;
 
-        // Trigger re-analysis if exclusion patterns changed
-        if (patternsChanged) {
+        // Trigger re-analysis if exclusion patterns or license check changed
+        if (patternsChanged || licenseCheckChanged) {
             refreshComponentAnalysis();
         }
     }
@@ -160,6 +165,7 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         settingsComponent.setCargoPathText(settings.cargoPath != null ? settings.cargoPath : "");
         settingsComponent.setManifestExclusionPatternsText(settings.manifestExclusionPatterns != null ? settings.manifestExclusionPatterns : "");
         settingsComponent.setReportFilePathText(settings.reportFilePath != null ? settings.reportFilePath : "");
+        settingsComponent.setLicenseCheckEnabledCheck(settings.licenseCheckEnabled);
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsConfigurable.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsConfigurable.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.NlsContexts;
 import com.intellij.serviceContainer.AlreadyDisposedException;
+import org.jboss.tools.intellij.componentanalysis.CAService;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.JComponent;
@@ -117,6 +118,9 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
 
         // Trigger re-analysis if exclusion patterns or license check changed
         if (patternsChanged || licenseCheckChanged) {
+            if (licenseCheckChanged) {
+                CAService.invalidateAllCaches();
+            }
             refreshComponentAnalysis();
         }
     }

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsState.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsState.java
@@ -69,6 +69,8 @@ public final class ApiSettingsState implements PersistentStateComponent<ApiSetti
 
     public String reportFilePath;
 
+    public boolean licenseCheckEnabled = true;
+
     public static ApiSettingsState getInstance() {
         ApiSettingsState state = ApplicationManager.getApplication().getService(ApiSettingsState.class);
         if (state.rhdaToken == null || state.rhdaToken.isBlank()) {


### PR DESCRIPTION
- Switch API to componentAnalysisWithLicense() for license-aware analysis
- Add licenseCheckEnabled setting (default true) with UI checkbox
- Detect license mismatch between manifest and LICENSE file (ERROR)
- Report incompatible dependency licenses (WARNING), merged into vulnerability annotations when both apply to the same dependency
- Quick fix to update manifest license with SPDX ID from LICENSE file
- Cache license summary alongside vulnerability data
- Invalidate all caches after license quick fix to trigger re-analysis
- Use WEAK_WARNING severity for recommendation-only dependencies
- Implement license field extraction for NPM, Maven, and Cargo; Go, Gradle, and Python return null (no standard license field)

**DRAFT** This is ready for review, however, it won't compile until next `trustify-da-java-client` update.