### PR TITLE
feat: add unknown severity handling to DockerfileAnnotator (TC-4728)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 caffeine = "3.1.8"
 commons-compress = "1.21"
 commons-io = "2.16.1"
-trustify-da-api-spec = "2.0.8"
+trustify-da-api-spec = "2.0.9"
 trustify-da-java-client = "0.0.17"
 github-api = "1.314"
 junit = "4.13.2"

--- a/src/main/java/org/jboss/tools/intellij/image/DockerfileAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/image/DockerfileAnnotator.java
@@ -59,6 +59,8 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                 severity = Severity.MEDIUM;
             } else if (source.getSummary().getLow() != null && source.getSummary().getLow() > 0) {
                 severity = Severity.LOW;
+            } else if (source.getSummary().getUnknown() != null && source.getSummary().getUnknown() > 0) {
+                severity = Severity.UNKNOWN;
             }
         }
         return severity;

--- a/src/test/java/org/jboss/tools/intellij/image/DockerfileAnnotatorTest.java
+++ b/src/test/java/org/jboss/tools/intellij/image/DockerfileAnnotatorTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.intellij.image;
+
+import io.github.guacsec.trustifyda.api.v5.Severity;
+import io.github.guacsec.trustifyda.api.v5.Source;
+import io.github.guacsec.trustifyda.api.v5.SourceSummary;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link DockerfileAnnotator#getSeverity(Source)} severity cascade logic.
+ */
+public class DockerfileAnnotatorTest {
+
+    private static Source createSourceWithSummary(Integer critical, Integer high, Integer medium, Integer low, Integer unknown) {
+        var summary = new SourceSummary();
+        summary.setCritical(critical);
+        summary.setHigh(high);
+        summary.setMedium(medium);
+        summary.setLow(low);
+        summary.setUnknown(unknown);
+        var source = new Source();
+        source.setSummary(summary);
+        return source;
+    }
+
+    /**
+     * Verifies that critical severity takes precedence over all others.
+     */
+    @Test
+    public void testGetSeverityCritical() {
+        Source source = createSourceWithSummary(1, 2, 3, 4, 5);
+        assertEquals(Severity.CRITICAL, DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that high severity is returned when no critical vulnerabilities exist.
+     */
+    @Test
+    public void testGetSeverityHigh() {
+        Source source = createSourceWithSummary(0, 1, 2, 3, 4);
+        assertEquals(Severity.HIGH, DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that medium severity is returned when no critical or high vulnerabilities exist.
+     */
+    @Test
+    public void testGetSeverityMedium() {
+        Source source = createSourceWithSummary(0, 0, 1, 2, 3);
+        assertEquals(Severity.MEDIUM, DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that low severity is returned when no critical, high, or medium vulnerabilities exist.
+     */
+    @Test
+    public void testGetSeverityLow() {
+        Source source = createSourceWithSummary(0, 0, 0, 1, 2);
+        assertEquals(Severity.LOW, DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that unknown severity is returned when only unknown-severity vulnerabilities exist.
+     */
+    @Test
+    public void testGetSeverityUnknown() {
+        Source source = createSourceWithSummary(0, 0, 0, 0, 1);
+        assertEquals(Severity.UNKNOWN, DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that null is returned when no vulnerabilities of any severity exist.
+     */
+    @Test
+    public void testGetSeverityNone() {
+        Source source = createSourceWithSummary(0, 0, 0, 0, 0);
+        assertNull(DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that null is returned when summary is null.
+     */
+    @Test
+    public void testGetSeverityNullSummary() {
+        var source = new Source();
+        assertNull(DockerfileAnnotator.getSeverity(source));
+    }
+
+    /**
+     * Verifies that null is returned when all severity counts are null.
+     */
+    @Test
+    public void testGetSeverityNullCounts() {
+        Source source = createSourceWithSummary(null, null, null, null, null);
+        assertNull(DockerfileAnnotator.getSeverity(source));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `UNKNOWN` branch to `getSeverity()` severity cascade in `DockerfileAnnotator`, ranked below `LOW`
- Bump `trustify-da-api-spec` from `2.0.8` to `2.0.9` for the new `UNKNOWN` enum value and `SourceSummary.getUnknown()` field
- Add comprehensive tests for the full severity cascade logic (critical, high, medium, low, unknown, none, null)

Implements [TC-4728](https://redhat.atlassian.net/browse/TC-4728)

## Test plan

- [x] `testGetSeverityUnknown` — verifies UNKNOWN returned when only unknown-severity vulns exist
- [x] `testGetSeverityCritical/High/Medium/Low` — regression tests for existing cascade
- [x] `testGetSeverityNone/NullSummary/NullCounts` — edge cases
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)