### PR TITLE
feat: add hardened image recommendations to DockerfileAnnotator (TC-4811)

### DIFF
--- a/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
+++ b/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
@@ -314,6 +314,11 @@ public final class ApiService {
         } else {
             System.setProperty("TRUSTIFY_DA_LICENSE_CHECK", "false");
         }
+        if (settings.recommendationsEnabled) {
+            System.setProperty("TRUSTIFY_DA_RECOMMENDATIONS_ENABLED", "true");
+        } else {
+            System.setProperty("TRUSTIFY_DA_RECOMMENDATIONS_ENABLED", "false");
+        }
 
         Optional<String> proxyUrlOpt = getProxyUrl();
         if (proxyUrlOpt.isPresent()) {

--- a/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
+++ b/src/main/java/org/jboss/tools/intellij/exhort/ApiService.java
@@ -315,9 +315,9 @@ public final class ApiService {
             System.setProperty("TRUSTIFY_DA_LICENSE_CHECK", "false");
         }
         if (settings.recommendationsEnabled) {
-            System.setProperty("TRUSTIFY_DA_RECOMMENDATIONS_ENABLED", "true");
+            System.setProperty("TRUSTIFY_DA_RECOMMEND", "true");
         } else {
-            System.setProperty("TRUSTIFY_DA_RECOMMENDATIONS_ENABLED", "false");
+            System.setProperty("TRUSTIFY_DA_RECOMMEND", "false");
         }
 
         Optional<String> proxyUrlOpt = getProxyUrl();

--- a/src/main/java/org/jboss/tools/intellij/image/DockerfileAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/image/DockerfileAnnotator.java
@@ -21,17 +21,22 @@ import com.intellij.lang.annotation.ExternalAnnotator;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.markup.EffectType;
+import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.profile.codeInspection.InspectionProjectProfileManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.serviceContainer.AlreadyDisposedException;
+import com.intellij.ui.JBColor;
 import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
 import io.github.guacsec.trustifyda.api.v5.DependencyReport;
 import io.github.guacsec.trustifyda.api.v5.ProviderReport;
+import io.github.guacsec.trustifyda.api.v5.RecommendationSource;
 import io.github.guacsec.trustifyda.api.v5.Severity;
 import io.github.guacsec.trustifyda.api.v5.Source;
 import io.github.guacsec.trustifyda.image.ImageRef;
 import org.jboss.tools.intellij.image.build.filetype.DockerfileFileType;
+import org.jboss.tools.intellij.settings.ApiSettingsState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -84,18 +89,32 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                 .map(providers -> providers
                         .values()
                         .stream()
-                        .map(ProviderReport::getSources)
+                        .anyMatch(provider -> hasVulnerabilities(provider) || hasProviderRecommendations(provider)))
+                .orElse(false);
+    }
+
+    private static boolean hasVulnerabilities(ProviderReport provider) {
+        return Optional.ofNullable(provider.getSources())
+                .map(sources -> sources.values().stream()
                         .filter(Objects::nonNull)
-                        .map(Map::entrySet)
-                        .flatMap(Collection::stream)
-                        .map(Map.Entry::getValue)
                         .map(Source::getSummary)
                         .filter(Objects::nonNull)
                         .anyMatch(s -> s.getTotal() != null && s.getTotal() > 0))
                 .orElse(false);
     }
 
-    static String generateMessage(String image, AnalysisReport report, String recommendation) {
+    private static boolean hasProviderRecommendations(ProviderReport provider) {
+        return Optional.ofNullable(provider.getRecommendations())
+                .map(recs -> recs.values().stream()
+                        .filter(Objects::nonNull)
+                        .map(RecommendationSource::getDependencies)
+                        .filter(Objects::nonNull)
+                        .anyMatch(deps -> !deps.isEmpty()))
+                .orElse(false);
+    }
+
+    static String generateMessage(String image, AnalysisReport report, String recommendation,
+                                   String hardenedRecommendation) {
         var messageBuilder = new StringBuilder(image);
 
         Optional.ofNullable(report.getProviders())
@@ -137,11 +156,17 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                     .append("Replace your image with RedHat UBI: ")
                     .append(recommendation);
         }
+        if (hardenedRecommendation != null) {
+            messageBuilder.append(System.lineSeparator())
+                    .append("A Red Hat Hardened Image is available: ")
+                    .append(hardenedRecommendation);
+        }
 
         return messageBuilder.toString();
     }
 
-    static String generateTooltip(String image, AnalysisReport report, String recommendation) {
+    static String generateTooltip(String image, AnalysisReport report, String recommendation,
+                                    String hardenedRecommendation) {
         var tooltipBuilder = new StringBuilder("<html>").append("<p>").append(image).append("</p>");
 
         Optional.ofNullable(report.getProviders())
@@ -188,6 +213,12 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                     .append(recommendation)
                     .append("</p>");
         }
+        if (hardenedRecommendation != null) {
+            tooltipBuilder.append("<p/>")
+                    .append("<p>A Red Hat Hardened Image is available: ")
+                    .append(hardenedRecommendation)
+                    .append("</p>");
+        }
 
         return tooltipBuilder.toString();
     }
@@ -210,6 +241,7 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                 .orElse(false);
     }
 
+    /** Returns the UBI image recommendation (from source-level dependencies), or null if none. */
     static String getRecommendation(AnalysisReport report, ImageRef imageRef) {
         return Optional.ofNullable(report.getProviders())
                 .flatMap(provider -> provider.values()
@@ -219,6 +251,7 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                         .filter(Objects::nonNull)
                         .map(Map::values)
                         .flatMap(Collection::stream)
+                        .filter(Objects::nonNull)
                         .map(Source::getDependencies)
                         .filter(Objects::nonNull)
                         .flatMap(Collection::stream)
@@ -233,12 +266,85 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                         .map(DependencyReport::getRecommendation)
                         .filter(Objects::nonNull)
                         .findAny())
-                .map(r -> new ImageRef(r.purl()).getImage().getNameWithoutTag())
+                .map(DockerfileAnnotator::toImageName)
                 .orElse(null);
     }
 
+    /** Returns the hardened image recommendation (from provider-level recommendations), or null if none. */
+    static String getHardenedRecommendation(AnalysisReport report, ImageRef imageRef) {
+        return Optional.ofNullable(report.getProviders())
+                .flatMap(provider -> provider.values()
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .map(ProviderReport::getRecommendations)
+                        .filter(Objects::nonNull)
+                        .flatMap(recs -> recs.entrySet().stream())
+                        .filter(entry -> entry.getValue() != null)
+                        .map(entry -> entry.getValue().getDependencies())
+                        .filter(Objects::nonNull)
+                        .flatMap(Collection::stream)
+                        .filter(r -> r.getRef() != null)
+                        .filter(r -> {
+                            try {
+                                return imageRef.getPackageURL().equals(r.getRef().purl());
+                            } catch (MalformedPackageURLException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .map(r -> r.getRecommendation())
+                        .filter(Objects::nonNull)
+                        .findAny())
+                .map(DockerfileAnnotator::toImageName)
+                .orElse(null);
+    }
+
+    private static String toImageName(io.github.guacsec.trustifyda.api.PackageRef ref) {
+        try {
+            var purl = ref.purl();
+            var qualifiers = purl.getQualifiers();
+            if (qualifiers != null && qualifiers.containsKey(ImageRef.REPOSITORY_QUALIFIER)) {
+                String repoUrl = qualifiers.get(ImageRef.REPOSITORY_QUALIFIER);
+                String decoded = fullyDecode(repoUrl);
+                if (!decoded.equals(repoUrl)) {
+                    var decodedQualifiers = new java.util.TreeMap<>(qualifiers);
+                    decodedQualifiers.put(ImageRef.REPOSITORY_QUALIFIER, decoded);
+                    purl = new com.github.packageurl.PackageURL(
+                            purl.getType(), purl.getNamespace(), purl.getName(),
+                            purl.getVersion(), decodedQualifiers, purl.getSubpath());
+                }
+            }
+            return new ImageRef(purl).getImage().getNameWithoutTag();
+        } catch (IllegalArgumentException | com.github.packageurl.MalformedPackageURLException e) {
+            LOG.warn("Failed to parse recommendation image from PURL: " + ref.ref(), e);
+            return null;
+        }
+    }
+
+    /** Repeatedly URL-decodes until the value stabilizes (handles double/triple encoding). */
+    private static String fullyDecode(String value) {
+        String previous = value;
+        for (int i = 0; i < 5; i++) {
+            String decoded = java.net.URLDecoder.decode(previous, java.nio.charset.StandardCharsets.UTF_8);
+            if (decoded.equals(previous)) {
+                break;
+            }
+            previous = decoded;
+        }
+        return previous;
+    }
+
     @NotNull
-    private static HighlightSeverity getHighlightSeverity(AnalysisReport report, String recommendation, boolean hasIssue, @NotNull PsiElement context) {
+    private static HighlightSeverity getHighlightSeverity(AnalysisReport report, String recommendation,
+                                                           String hardenedRecommendation, boolean hasIssue,
+                                                           @NotNull PsiElement context) {
+        // Recommendation-only (no vulnerabilities): use INFORMATION severity (blue)
+        if (!hasIssue && !hasIssue(report)) {
+            boolean hasAnyRecommendation = recommendation != null || hardenedRecommendation != null;
+            if (hasAnyRecommendation) {
+                return HighlightSeverity.INFORMATION;
+            }
+        }
+
         // Get the configured severity from the inspection settings
         final InspectionProfileEntry inspection = getInspection(context);
         if (inspection != null) {
@@ -335,20 +441,37 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                         && elements != null && !elements.isEmpty()) {
                     if (isReportAvailable(report)) {
                         var hasIssue = hasIssue(report);
-                        var recommendation = getRecommendation(report, value.getImageRef());
+                        boolean recommendationsEnabled = ApiSettingsState.getInstance().recommendationsEnabled;
+                        var recommendation = recommendationsEnabled
+                                ? getRecommendation(report, value.getImageRef()) : null;
+                        var hardenedRecommendation = recommendationsEnabled
+                                ? getHardenedRecommendation(report, value.getImageRef()) : null;
 
-                        var message = generateMessage(key.getImageName(), report, recommendation);
-                        var tooltip = generateTooltip(key.getImageName(), report, recommendation);
+                        var message = generateMessage(key.getImageName(), report,
+                                recommendation, hardenedRecommendation);
+                        var tooltip = generateTooltip(key.getImageName(), report,
+                                recommendation, hardenedRecommendation);
 
                         elements.forEach(e -> {
-                            var severity = getHighlightSeverity(report, recommendation, hasIssue, e);
+                            var severity = getHighlightSeverity(report, recommendation, hardenedRecommendation, hasIssue, e);
                             if (e != null) {
                                 var builder = holder
                                         .newAnnotation(severity, message)
                                         .tooltip(tooltip)
-                                        .range(e)
-                                        .withFix(new ImageReportIntentionAction())
-                                        .withFix(new UBIIntentionAction());
+                                        .range(e);
+                                if (severity == HighlightSeverity.INFORMATION) {
+                                    var attrs = new TextAttributes();
+                                    attrs.setEffectType(EffectType.WAVE_UNDERSCORE);
+                                    attrs.setEffectColor(JBColor.BLUE);
+                                    builder = builder.enforcedTextAttributes(attrs);
+                                }
+                                builder = builder.withFix(new ImageReportIntentionAction());
+                                if (recommendation != null) {
+                                    builder.withFix(new UBIIntentionAction());
+                                }
+                                if (hardenedRecommendation != null) {
+                                    builder.withFix(new HardenedImageIntentionAction());
+                                }
                                 builder.create();
                             }
                         });

--- a/src/main/java/org/jboss/tools/intellij/image/DockerfileAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/image/DockerfileAnnotator.java
@@ -40,13 +40,17 @@ import org.jboss.tools.intellij.settings.ApiSettingsState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import io.github.guacsec.trustifyda.api.PackageRef;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.Info, Map<BaseImage, DockerfileAnnotator.Result>> {
 
@@ -243,57 +247,55 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
 
     /** Returns the UBI image recommendation (from source-level dependencies), or null if none. */
     static String getRecommendation(AnalysisReport report, ImageRef imageRef) {
-        return Optional.ofNullable(report.getProviders())
-                .flatMap(provider -> provider.values()
-                        .stream()
-                        .filter(Objects::nonNull)
-                        .map(ProviderReport::getSources)
-                        .filter(Objects::nonNull)
-                        .map(Map::values)
-                        .flatMap(Collection::stream)
-                        .filter(Objects::nonNull)
-                        .map(Source::getDependencies)
-                        .filter(Objects::nonNull)
-                        .flatMap(Collection::stream)
-                        .filter(r -> r.getRef() != null)
-                        .filter(r -> {
-                            try {
-                                return imageRef.getPackageURL().equals(r.getRef().purl());
-                            } catch (MalformedPackageURLException e) {
-                                throw new RuntimeException(e);
-                            }
-                        })
-                        .map(DependencyReport::getRecommendation)
-                        .filter(Objects::nonNull)
-                        .findAny())
-                .map(DockerfileAnnotator::toImageName)
-                .orElse(null);
+        var deps = Optional.ofNullable(report.getProviders())
+                .stream()
+                .flatMap(provider -> provider.values().stream())
+                .filter(Objects::nonNull)
+                .map(ProviderReport::getSources)
+                .filter(Objects::nonNull)
+                .map(Map::values)
+                .flatMap(Collection::stream)
+                .filter(Objects::nonNull)
+                .map(Source::getDependencies)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream);
+        return findMatchingRecommendation(deps, imageRef, DependencyReport::getRef, DependencyReport::getRecommendation);
     }
 
     /** Returns the hardened image recommendation (from provider-level recommendations), or null if none. */
     static String getHardenedRecommendation(AnalysisReport report, ImageRef imageRef) {
-        return Optional.ofNullable(report.getProviders())
-                .flatMap(provider -> provider.values()
-                        .stream()
-                        .filter(Objects::nonNull)
-                        .map(ProviderReport::getRecommendations)
-                        .filter(Objects::nonNull)
-                        .flatMap(recs -> recs.entrySet().stream())
-                        .filter(entry -> entry.getValue() != null)
-                        .map(entry -> entry.getValue().getDependencies())
-                        .filter(Objects::nonNull)
-                        .flatMap(Collection::stream)
-                        .filter(r -> r.getRef() != null)
-                        .filter(r -> {
-                            try {
-                                return imageRef.getPackageURL().equals(r.getRef().purl());
-                            } catch (MalformedPackageURLException e) {
-                                throw new RuntimeException(e);
-                            }
-                        })
-                        .map(r -> r.getRecommendation())
-                        .filter(Objects::nonNull)
-                        .findAny())
+        var deps = Optional.ofNullable(report.getProviders())
+                .stream()
+                .flatMap(provider -> provider.values().stream())
+                .filter(Objects::nonNull)
+                .map(ProviderReport::getRecommendations)
+                .filter(Objects::nonNull)
+                .flatMap(recs -> recs.entrySet().stream())
+                .filter(entry -> entry.getValue() != null)
+                .map(entry -> entry.getValue().getDependencies())
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream);
+        return findMatchingRecommendation(deps, imageRef,
+                io.github.guacsec.trustifyda.api.v5.RecommendationReport::getRef,
+                io.github.guacsec.trustifyda.api.v5.RecommendationReport::getRecommendation);
+    }
+
+    private static <T> String findMatchingRecommendation(Stream<T> items, ImageRef imageRef,
+                                                          Function<T, PackageRef> refExtractor,
+                                                          Function<T, PackageRef> recommendationExtractor) {
+        return items
+                .filter(r -> refExtractor.apply(r) != null)
+                .filter(r -> {
+                    try {
+                        return imageRef.getPackageURL().equals(refExtractor.apply(r).purl());
+                    } catch (MalformedPackageURLException e) {
+                        LOG.warn("Skipping recommendation with malformed PURL", e);
+                        return false;
+                    }
+                })
+                .map(recommendationExtractor)
+                .filter(Objects::nonNull)
+                .findAny()
                 .map(DockerfileAnnotator::toImageName)
                 .orElse(null);
     }
@@ -338,7 +340,7 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                                                            String hardenedRecommendation, boolean hasIssue,
                                                            @NotNull PsiElement context) {
         // Recommendation-only (no vulnerabilities): use INFORMATION severity (blue)
-        if (!hasIssue && !hasIssue(report)) {
+        if (!hasIssue) {
             boolean hasAnyRecommendation = recommendation != null || hardenedRecommendation != null;
             if (hasAnyRecommendation) {
                 return HighlightSeverity.INFORMATION;
@@ -466,11 +468,9 @@ public class DockerfileAnnotator extends ExternalAnnotator<DockerfileAnnotator.I
                                     builder = builder.enforcedTextAttributes(attrs);
                                 }
                                 builder = builder.withFix(new ImageReportIntentionAction());
-                                if (recommendation != null) {
-                                    builder.withFix(new UBIIntentionAction());
-                                }
+                                builder = builder.withFix(new UBIIntentionAction());
                                 if (hardenedRecommendation != null) {
-                                    builder.withFix(new HardenedImageIntentionAction());
+                                    builder = builder.withFix(new HardenedImageIntentionAction());
                                 }
                                 builder.create();
                             }

--- a/src/main/java/org/jboss/tools/intellij/image/HardenedImageIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/image/HardenedImageIntentionAction.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.intellij.image;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import org.jboss.tools.intellij.image.build.filetype.DockerfileFileType;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
+
+/** Intention action that directs users to the Red Hat Hardened Container Images catalog. */
+public class HardenedImageIntentionAction implements IntentionAction {
+
+    public static final String HARDENED_IMAGE_LINK = "https://catalog.redhat.com/software/containers/search?gs&q=hardened";
+
+    @Override
+    public @IntentionName @NotNull String getText() {
+        return "Switch to a Red Hat Hardened Image for enhanced security";
+    }
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return "RHDA";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile psiFile) {
+        return DockerfileFileType.isDockerfile(psiFile);
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile psiFile) throws IncorrectOperationException {
+        BrowserUtil.browse(URI.create(HARDENED_IMAGE_LINK));
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return false;
+    }
+}

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsComponent.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsComponent.java
@@ -94,6 +94,8 @@ public class ApiSettingsComponent {
             + "<br>Leave empty to use temporary files only.</html>";
     private final static String licenseCheckEnabledLabel = "<html>Component Analysis > License Check"
             + "<br>Enables license compatibility checking and notifications for incompatible dependencies.</html>";
+    private final static String recommendationsEnabledLabel = "<html>Component Analysis > Recommendations"
+            + "<br>Enables package version and image recommendations from Red Hat.</html>";
 
     private final JPanel mainPanel;
 
@@ -131,6 +133,7 @@ public class ApiSettingsComponent {
     private final JBScrollPane manifestExclusionPatternsScrollPane;
     private final TextFieldWithBrowseButton reportFilePathText;
     private final JBCheckBox licenseCheckEnabledCheck;
+    private final JBCheckBox recommendationsEnabledCheck;
 
 
     public ApiSettingsComponent() {
@@ -279,6 +282,7 @@ public class ApiSettingsComponent {
         batchMetadataCheck = new JBCheckBox("Include metadata in batch results");
 
         licenseCheckEnabledCheck = new JBCheckBox("Enable license compatibility checking");
+        recommendationsEnabledCheck = new JBCheckBox("Enable package and image recommendations");
 
         manifestExclusionPatternsText = new JBTextArea();
         manifestExclusionPatternsText.setRows(5);
@@ -357,6 +361,8 @@ public class ApiSettingsComponent {
                 .addSeparator(10)
                 .addVerticalGap(10)
                 .addLabeledComponent(new JBLabel(licenseCheckEnabledLabel), licenseCheckEnabledCheck, 1, true)
+                .addVerticalGap(10)
+                .addLabeledComponent(new JBLabel(recommendationsEnabledLabel), recommendationsEnabledCheck, 1, true)
                 .addSeparator(10)
                 .addVerticalGap(10)
                 .addLabeledComponent(new JBLabel(manifestExclusionPatternsLabel), manifestExclusionPatternsScrollPane, 1, true)
@@ -642,5 +648,13 @@ public class ApiSettingsComponent {
 
     public void setLicenseCheckEnabledCheck(boolean selected) {
         licenseCheckEnabledCheck.setSelected(selected);
+    }
+
+    public boolean getRecommendationsEnabledCheck() {
+        return recommendationsEnabledCheck.isSelected();
+    }
+
+    public void setRecommendationsEnabledCheck(boolean selected) {
+        recommendationsEnabledCheck.setSelected(selected);
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsConfigurable.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsConfigurable.java
@@ -77,6 +77,7 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         modified |= !settingsComponent.getManifestExclusionPatternsText().equals(settings.manifestExclusionPatterns);
         modified |= !settingsComponent.getReportFilePathText().equals(settings.reportFilePath);
         modified |= settingsComponent.getLicenseCheckEnabledCheck() != settings.licenseCheckEnabled;
+        modified |= settingsComponent.getRecommendationsEnabledCheck() != settings.recommendationsEnabled;
         return modified;
     }
 
@@ -114,9 +115,11 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         settings.batchContinueOnError = settingsComponent.getBatchContinueOnErrorCheck();
         settings.batchMetadata = settingsComponent.getBatchMetadataCheck();
 
-        // Check if license check setting changed
+        // Check if license check or recommendations setting changed
         boolean licenseCheckChanged = settingsComponent.getLicenseCheckEnabledCheck() != settings.licenseCheckEnabled;
         settings.licenseCheckEnabled = settingsComponent.getLicenseCheckEnabledCheck();
+        boolean recommendationsChanged = settingsComponent.getRecommendationsEnabledCheck() != settings.recommendationsEnabled;
+        settings.recommendationsEnabled = settingsComponent.getRecommendationsEnabledCheck();
 
         // Check if exclusion patterns changed
         String oldPatterns = settings.manifestExclusionPatterns;
@@ -124,9 +127,9 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         boolean patternsChanged = !Objects.equals(oldPatterns, newPatterns);
         settings.manifestExclusionPatterns = newPatterns;
 
-        // Trigger re-analysis if exclusion patterns or license check changed
-        if (patternsChanged || licenseCheckChanged) {
-            if (licenseCheckChanged) {
+        // Trigger re-analysis if exclusion patterns, license check, or recommendations changed
+        if (patternsChanged || licenseCheckChanged || recommendationsChanged) {
+            if (licenseCheckChanged || recommendationsChanged) {
                 CAService.invalidateAllCaches();
             }
             refreshComponentAnalysis();
@@ -182,6 +185,7 @@ public class ApiSettingsConfigurable implements com.intellij.openapi.options.Con
         settingsComponent.setManifestExclusionPatternsText(settings.manifestExclusionPatterns != null ? settings.manifestExclusionPatterns : "");
         settingsComponent.setReportFilePathText(settings.reportFilePath != null ? settings.reportFilePath : "");
         settingsComponent.setLicenseCheckEnabledCheck(settings.licenseCheckEnabled);
+        settingsComponent.setRecommendationsEnabledCheck(settings.recommendationsEnabled);
     }
 
     @Override

--- a/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsState.java
+++ b/src/main/java/org/jboss/tools/intellij/settings/ApiSettingsState.java
@@ -76,6 +76,8 @@ public final class ApiSettingsState implements PersistentStateComponent<ApiSetti
 
     public boolean licenseCheckEnabled = true;
 
+    public boolean recommendationsEnabled = true;
+
     public static ApiSettingsState getInstance() {
         ApiSettingsState state = ApplicationManager.getApplication().getService(ApiSettingsState.class);
         if (state.rhdaToken == null || state.rhdaToken.isBlank()) {

--- a/src/test/java/org/jboss/tools/intellij/image/DockerfileAnnotatorRecommendationTest.java
+++ b/src/test/java/org/jboss/tools/intellij/image/DockerfileAnnotatorRecommendationTest.java
@@ -1,0 +1,365 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.intellij.image;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import io.github.guacsec.trustifyda.api.PackageRef;
+import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
+import io.github.guacsec.trustifyda.api.v5.DependencyReport;
+import io.github.guacsec.trustifyda.api.v5.ProviderReport;
+import io.github.guacsec.trustifyda.api.v5.RecommendationReport;
+import io.github.guacsec.trustifyda.api.v5.RecommendationSource;
+import io.github.guacsec.trustifyda.api.v5.Source;
+import io.github.guacsec.trustifyda.api.v5.SourceSummary;
+import io.github.guacsec.trustifyda.image.ImageRef;
+import org.junit.Test;
+
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for recommendation message and tooltip generation in DockerfileAnnotator,
+ * covering UBI, hardened image, and disabled recommendation scenarios.
+ */
+public class DockerfileAnnotatorRecommendationTest {
+
+    private static final String IMAGE_DIGEST = "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    private static final String UBI_DIGEST = "sha256:b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b200";
+    private static final String HARDENED_DIGEST = "sha256:c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b20000";
+
+    // ── generateMessage tests ─────────────────────────────────────────────────
+
+    @Test
+    public void testGenerateMessageWithUbiRecommendation() {
+        AnalysisReport report = new AnalysisReport();
+        String message = DockerfileAnnotator.generateMessage("nginx:latest", report, "ubi9/ubi", null);
+
+        assertTrue("Should contain UBI recommendation",
+                message.contains("Replace your image with RedHat UBI: ubi9/ubi"));
+        assertFalse("Should not contain hardened recommendation",
+                message.contains("Hardened Image"));
+    }
+
+    @Test
+    public void testGenerateMessageWithHardenedRecommendation() {
+        AnalysisReport report = new AnalysisReport();
+        String message = DockerfileAnnotator.generateMessage("nginx:latest", report, null, "hardened-nginx");
+
+        assertTrue("Should contain hardened recommendation",
+                message.contains("A Red Hat Hardened Image is available: hardened-nginx"));
+        assertFalse("Should not contain UBI recommendation",
+                message.contains("Replace your image with RedHat UBI"));
+    }
+
+    @Test
+    public void testGenerateMessageWithBothRecommendations() {
+        AnalysisReport report = new AnalysisReport();
+        String message = DockerfileAnnotator.generateMessage("nginx:latest", report, "ubi9/ubi", "hardened-nginx");
+
+        assertTrue("Should contain UBI recommendation",
+                message.contains("Replace your image with RedHat UBI: ubi9/ubi"));
+        assertTrue("Should contain hardened recommendation",
+                message.contains("A Red Hat Hardened Image is available: hardened-nginx"));
+    }
+
+    @Test
+    public void testGenerateMessageWithNoRecommendations() {
+        AnalysisReport report = new AnalysisReport();
+        String message = DockerfileAnnotator.generateMessage("nginx:latest", report, null, null);
+
+        assertEquals("Should only contain image name", "nginx:latest", message);
+    }
+
+    // ── generateTooltip tests ─────────────────────────────────────────────────
+
+    @Test
+    public void testGenerateTooltipWithHardenedRecommendation() {
+        AnalysisReport report = new AnalysisReport();
+        String tooltip = DockerfileAnnotator.generateTooltip("nginx:latest", report, null, "hardened-nginx");
+
+        assertTrue("Should contain hardened recommendation",
+                tooltip.contains("A Red Hat Hardened Image is available: hardened-nginx"));
+    }
+
+    @Test
+    public void testGenerateTooltipWithBothRecommendations() {
+        AnalysisReport report = new AnalysisReport();
+        String tooltip = DockerfileAnnotator.generateTooltip("nginx:latest", report, "ubi9/ubi", "hardened-nginx");
+
+        assertTrue("Should contain UBI recommendation",
+                tooltip.contains("Replace your image with RedHat UBI: ubi9/ubi"));
+        assertTrue("Should contain hardened recommendation",
+                tooltip.contains("A Red Hat Hardened Image is available: hardened-nginx"));
+    }
+
+    @Test
+    public void testGenerateTooltipWithNoRecommendations() {
+        AnalysisReport report = new AnalysisReport();
+        String tooltip = DockerfileAnnotator.generateTooltip("nginx:latest", report, null, null);
+
+        assertFalse("Should not contain UBI text", tooltip.contains("Replace your image"));
+        assertFalse("Should not contain hardened text", tooltip.contains("Hardened Image"));
+        assertTrue("Should contain image name", tooltip.contains("nginx:latest"));
+    }
+
+    // ── getRecommendation tests (reads from source-level dependencies) ───────
+
+    @Test
+    public void testGetRecommendationFromSources() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        AnalysisReport report = buildReportWithUbiSource(imagePurl,
+                buildOciPurl("ubi", UBI_DIGEST, "registry.access.redhat.com/ubi9/ubi"));
+
+        String recommendation = DockerfileAnnotator.getRecommendation(report, imageRef);
+
+        assertNotNull("UBI recommendation should be present", recommendation);
+        assertTrue("Should contain ubi path", recommendation.contains("ubi9/ubi"));
+    }
+
+    @Test
+    public void testGetRecommendationReturnsNullWhenNoSources() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        // Report with only provider-level recommendations, no sources
+        AnalysisReport report = buildReportWithHardenedRecommendation(imagePurl,
+                buildOciPurl("hardened-nginx", HARDENED_DIGEST, "registry.access.redhat.com/hardened/nginx"));
+
+        String recommendation = DockerfileAnnotator.getRecommendation(report, imageRef);
+
+        assertNull("UBI recommendation should be null when no sources exist", recommendation);
+    }
+
+    @Test
+    public void testGetRecommendationHandlesNullSourceValue() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        ProviderReport providerReport = new ProviderReport();
+        providerReport.putSourcesItem("ubi", null);
+
+        AnalysisReport report = new AnalysisReport();
+        report.putProvidersItem("rhtpa", providerReport);
+
+        String recommendation = DockerfileAnnotator.getRecommendation(report, imageRef);
+
+        assertNull("Should return null for null source value", recommendation);
+    }
+
+    // ── getHardenedRecommendation tests (reads from provider-level recommendations) ──
+
+    @Test
+    public void testGetHardenedRecommendationFromProviderRecommendations() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        AnalysisReport report = buildReportWithHardenedRecommendation(imagePurl,
+                buildOciPurl("hardened-nginx", HARDENED_DIGEST, "registry.access.redhat.com/hardened/nginx"));
+
+        String recommendation = DockerfileAnnotator.getHardenedRecommendation(report, imageRef);
+
+        assertNotNull("Hardened recommendation should be present", recommendation);
+        assertTrue("Should contain hardened path", recommendation.contains("hardened"));
+    }
+
+    @Test
+    public void testGetHardenedRecommendationReturnsNullWhenOnlySourcesExist() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        // Report with only source-level dependencies, no provider-level recommendations
+        AnalysisReport report = buildReportWithUbiSource(imagePurl,
+                buildOciPurl("ubi", UBI_DIGEST, "registry.access.redhat.com/ubi9/ubi"));
+
+        String recommendation = DockerfileAnnotator.getHardenedRecommendation(report, imageRef);
+
+        assertNull("Hardened recommendation should be null when only sources exist", recommendation);
+    }
+
+    @Test
+    public void testGetBothRecommendationsFromMixedReport() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        // Build a report with both source-level UBI and provider-level hardened
+        PackageURL ubiPurl = buildOciPurl("ubi", UBI_DIGEST, "registry.access.redhat.com/ubi9/ubi");
+        PackageURL hardenedPurl = buildOciPurl("hardened-nginx", HARDENED_DIGEST, "registry.access.redhat.com/hardened/nginx");
+
+        DependencyReport dep = new DependencyReport();
+        dep.setRef(new PackageRef(imagePurl));
+        dep.setRecommendation(new PackageRef(ubiPurl));
+        Source source = new Source();
+        source.addDependenciesItem(dep);
+
+        RecommendationReport recReport = new RecommendationReport();
+        recReport.setRef(new PackageRef(imagePurl));
+        recReport.setRecommendation(new PackageRef(hardenedPurl));
+        RecommendationSource recSource = new RecommendationSource();
+        recSource.addDependenciesItem(recReport);
+
+        ProviderReport providerReport = new ProviderReport();
+        providerReport.putSourcesItem("ubi", source);
+        providerReport.putRecommendationsItem("hardened", recSource);
+
+        AnalysisReport report = new AnalysisReport();
+        report.putProvidersItem("rhtpa", providerReport);
+
+        String ubiRec = DockerfileAnnotator.getRecommendation(report, imageRef);
+        String hardenedRec = DockerfileAnnotator.getHardenedRecommendation(report, imageRef);
+
+        assertNotNull("UBI recommendation should be present", ubiRec);
+        assertTrue("Should contain ubi path", ubiRec.contains("ubi9/ubi"));
+        assertNotNull("Hardened recommendation should be present", hardenedRec);
+        assertTrue("Should contain hardened path", hardenedRec.contains("hardened"));
+    }
+
+    @Test
+    public void testGetRecommendationsReturnNullForEmptyReport() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+        AnalysisReport report = new AnalysisReport();
+
+        String ubiRec = DockerfileAnnotator.getRecommendation(report, imageRef);
+        String hardenedRec = DockerfileAnnotator.getHardenedRecommendation(report, imageRef);
+
+        assertNull("UBI recommendation should be null for empty report", ubiRec);
+        assertNull("Hardened recommendation should be null for empty report", hardenedRec);
+    }
+
+    // ── isReportAvailable tests ──────────────────────────────────────────────
+
+    @Test
+    public void testIsReportAvailableWithVulnerabilities() {
+        SourceSummary summary = new SourceSummary();
+        summary.setTotal(5);
+        Source source = new Source();
+        source.setSummary(summary);
+
+        ProviderReport providerReport = new ProviderReport();
+        providerReport.putSourcesItem("snyk", source);
+
+        AnalysisReport report = new AnalysisReport();
+        report.putProvidersItem("rhtpa", providerReport);
+
+        assertTrue("Should be available when vulnerabilities exist",
+                DockerfileAnnotator.isReportAvailable(report));
+    }
+
+    @Test
+    public void testIsReportAvailableWithOnlyRecommendations() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        PackageURL hardenedPurl = buildOciPurl("hardened-nginx", HARDENED_DIGEST, "registry.access.redhat.com/hardened/nginx");
+
+        AnalysisReport report = buildReportWithHardenedRecommendation(imagePurl, hardenedPurl);
+
+        assertTrue("Should be available when provider-level recommendations exist",
+                DockerfileAnnotator.isReportAvailable(report));
+    }
+
+    @Test
+    public void testIsReportAvailableReturnsFalseForEmptyReport() {
+        AnalysisReport report = new AnalysisReport();
+
+        assertFalse("Should not be available for empty report",
+                DockerfileAnnotator.isReportAvailable(report));
+    }
+
+    @Test
+    public void testIsReportAvailableReturnsFalseForZeroVulnsAndNoRecommendations() {
+        SourceSummary summary = new SourceSummary();
+        summary.setTotal(0);
+        Source source = new Source();
+        source.setSummary(summary);
+
+        ProviderReport providerReport = new ProviderReport();
+        providerReport.putSourcesItem("snyk", source);
+
+        AnalysisReport report = new AnalysisReport();
+        report.putProvidersItem("rhtpa", providerReport);
+
+        assertFalse("Should not be available when zero vulns and no recommendations",
+                DockerfileAnnotator.isReportAvailable(report));
+    }
+
+    // ── Double-encoded PURL tests ─────────────────────────────────────────────
+
+    @Test
+    public void testGetHardenedRecommendationWithDoubleEncodedPurl() throws MalformedPackageURLException {
+        PackageURL imagePurl = buildOciPurl("nginx", IMAGE_DIGEST, "docker.io/library/nginx");
+        ImageRef imageRef = new ImageRef(imagePurl);
+
+        // Simulate backend sending double-encoded repository_url (e.g., quay.io%252Fhummingbird%252Fgo)
+        TreeMap<String, String> qualifiers = new TreeMap<>();
+        qualifiers.put("repository_url", "quay.io%2Fhummingbird%2Fgo");
+        PackageURL hardenedPurl = new PackageURL("oci", null, "go", HARDENED_DIGEST, qualifiers, null);
+
+        AnalysisReport report = buildReportWithHardenedRecommendation(imagePurl, hardenedPurl);
+
+        String recommendation = DockerfileAnnotator.getHardenedRecommendation(report, imageRef);
+
+        assertNotNull("Should parse double-encoded PURL successfully", recommendation);
+        assertTrue("Should contain decoded path", recommendation.contains("quay.io/hummingbird/go"));
+    }
+
+    // ── Helper methods ───────────────────────────────────────────────────────
+
+    private static PackageURL buildOciPurl(String name, String digest, String repositoryUrl)
+            throws MalformedPackageURLException {
+        TreeMap<String, String> qualifiers = new TreeMap<>();
+        if (repositoryUrl != null && !repositoryUrl.equalsIgnoreCase(name)) {
+            qualifiers.put("repository_url", repositoryUrl.toLowerCase());
+        }
+        return new PackageURL("oci", null, name.toLowerCase(), digest, qualifiers, null);
+    }
+
+    /** Builds a report with a UBI recommendation in source-level dependencies. */
+    private static AnalysisReport buildReportWithUbiSource(PackageURL imagePurl, PackageURL ubiPurl) {
+        DependencyReport dep = new DependencyReport();
+        dep.setRef(new PackageRef(imagePurl));
+        dep.setRecommendation(new PackageRef(ubiPurl));
+
+        Source source = new Source();
+        source.addDependenciesItem(dep);
+
+        ProviderReport providerReport = new ProviderReport();
+        providerReport.putSourcesItem("ubi", source);
+
+        AnalysisReport report = new AnalysisReport();
+        report.putProvidersItem("rhtpa", providerReport);
+        return report;
+    }
+
+    /** Builds a report with a hardened recommendation in provider-level recommendations. */
+    private static AnalysisReport buildReportWithHardenedRecommendation(PackageURL imagePurl, PackageURL hardenedPurl) {
+        RecommendationReport recReport = new RecommendationReport();
+        recReport.setRef(new PackageRef(imagePurl));
+        recReport.setRecommendation(new PackageRef(hardenedPurl));
+
+        RecommendationSource recSource = new RecommendationSource();
+        recSource.addDependenciesItem(recReport);
+
+        ProviderReport providerReport = new ProviderReport();
+        providerReport.putRecommendationsItem("hardened", recSource);
+
+        AnalysisReport report = new AnalysisReport();
+        report.putProvidersItem("rhtpa", providerReport);
+        return report;
+    }
+}

--- a/src/test/java/org/jboss/tools/intellij/settings/ApiSettingsStateTest.java
+++ b/src/test/java/org/jboss/tools/intellij/settings/ApiSettingsStateTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+
+package org.jboss.tools.intellij.settings;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for ApiSettingsState field defaults and persistence behavior.
+ * Uses direct instantiation to avoid IntelliJ platform dependencies.
+ */
+public class ApiSettingsStateTest {
+
+    /** Verifies that recommendationsEnabled defaults to true. */
+    @Test
+    public void testRecommendationsEnabledDefaultsToTrue() {
+        ApiSettingsState state = new ApiSettingsState();
+        assertTrue("recommendationsEnabled should default to true", state.recommendationsEnabled);
+    }
+
+    /** Verifies that recommendationsEnabled can be toggled to false. */
+    @Test
+    public void testRecommendationsEnabledCanBeDisabled() {
+        // Given a settings state with defaults
+        ApiSettingsState state = new ApiSettingsState();
+
+        // When disabling recommendations
+        state.recommendationsEnabled = false;
+
+        // Then the value is persisted
+        assertFalse("recommendationsEnabled should be false after disabling", state.recommendationsEnabled);
+    }
+
+    /** Verifies that licenseCheckEnabled defaults to true (existing behavior). */
+    @Test
+    public void testLicenseCheckEnabledDefaultsToTrue() {
+        ApiSettingsState state = new ApiSettingsState();
+        assertTrue("licenseCheckEnabled should default to true", state.licenseCheckEnabled);
+    }
+}


### PR DESCRIPTION
## Summary
- Add support for Red Hat Hardened Image recommendations in Dockerfile annotations, alongside existing UBI recommendations
- Hardened recommendations are read from provider-level `recommendations` in the analysis report
- Show blue (INFORMATION severity) wavy underlines when only recommendations exist (no vulnerabilities)
- Add `HardenedImageIntentionAction` quick fix to open the Red Hat Hardened Container Images catalog
- Add a recommendations toggle in plugin settings (`Settings > Dependency Analytics > Recommendations`)
- Fix `isReportAvailable()` to consider provider-level recommendations, not just vulnerability counts
- Fix NPE when source entry value is null in recommendation stream
- Handle URL-encoded PURLs from the backend (double/triple encoding) via `fullyDecode()`

## Test plan
- [x] Unit tests for `generateMessage` / `generateTooltip` with UBI, hardened, both, and none
- [x] Unit tests for `getRecommendation` (source-level) and `getHardenedRecommendation` (provider-level)
- [x] Unit tests for `isReportAvailable` with vulns, recommendations only, empty, zero vulns
- [x] Unit test for double-encoded PURL handling
- [x] Unit tests for `ApiSettingsState` defaults
- [x] Manual verification in IntelliJ with local backend

Implements [TC-4811](https://redhat.atlassian.net/browse/TC-4811)

🤖 Generated with [Claude Code](https://claude.com/claude-code)