### PR TITLE
feat: surface full remediation UX (fix versions, advisory info, vendor ordering) (TC-5023)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 caffeine = "3.1.8"
 commons-compress = "1.21"
 commons-io = "2.16.1"
-trustify-da-api-spec = "2.0.9"
+trustify-da-api-spec = "2.0.12"
 trustify-da-java-client = "0.0.17"
 github-api = "1.314"
 junit = "4.13.2"

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAAnnotator.java
@@ -30,9 +30,12 @@ import com.intellij.profile.codeInspection.InspectionProjectProfileManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.serviceContainer.AlreadyDisposedException;
+import io.github.guacsec.trustifyda.api.v5.AdvisoryRemediation;
 import io.github.guacsec.trustifyda.api.v5.DependencyReport;
+import io.github.guacsec.trustifyda.api.v5.Issue;
 import io.github.guacsec.trustifyda.api.v5.LicenseIdentifier;
 import io.github.guacsec.trustifyda.api.v5.RecommendationReport;
+import io.github.guacsec.trustifyda.api.v5.Severity;
 import io.github.guacsec.trustifyda.license.LicenseCheck.IncompatibleDependency;
 import io.github.guacsec.trustifyda.license.LicenseCheck.LicenseSummary;
 import io.github.guacsec.trustifyda.license.LicenseCheck.ProjectLicenseSummary;
@@ -42,8 +45,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -173,43 +178,52 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                     Map<VulnerabilitySource, DependencyReport> quickfixes = new HashMap<>();
 
                     if (hasReports) {
-                        reports.forEach((source, report) -> {
-                            if (report.getIssues() != null && !report.getIssues().isEmpty()) {
-                                messageBuilder.append(System.lineSeparator());
-                                tooltipBuilder.append("<p/>");
+                        // Sort reports so Red Hat / RHLW sources appear first
+                        List<Map.Entry<VulnerabilitySource, DependencyReport>> sortedReports = new ArrayList<>(reports.entrySet());
+                        sortedReports.sort(Comparator.comparingInt(e ->
+                                CAIntentionAction.isRedHatSource(e.getKey().getSource()) ? 0 : 1));
 
-                                if (source.getProvider().equals(source.getSource())) {
-                                    messageBuilder.append(source.getProvider())
-                                            .append(" vulnerability info: ");
-                                    tooltipBuilder.append("<p>")
-                                            .append(escapeHtml(source.getProvider()))
-                                            .append(" vulnerability info:</p>");
-                                } else {
-                                    messageBuilder.append(source.getSource())
-                                            .append(" (")
-                                            .append(source.getProvider())
-                                            .append(") vulnerability info: ");
-                                    tooltipBuilder.append("<p>")
-                                            .append(escapeHtml(source.getSource()))
-                                            .append(" (")
-                                            .append(escapeHtml(source.getProvider()))
-                                            .append(") vulnerability info:</p>");
+                        boolean hasVulnerabilities = sortedReports.stream()
+                                .anyMatch(e -> e.getValue().getIssues() != null && !e.getValue().getIssues().isEmpty());
+
+                        if (hasVulnerabilities) {
+                            messageBuilder.append(System.lineSeparator())
+                                    .append("Vulnerabilities: TOTAL (CRITICAL/HIGH/MEDIUM/LOW/UNKNOWN):");
+                            tooltipBuilder.append("<p/>")
+                                    .append("<p>Vulnerabilities: TOTAL (CRITICAL/HIGH/MEDIUM/LOW/UNKNOWN):</p>");
+                        }
+
+                        boolean hasFixOptions = false;
+
+                        for (Map.Entry<VulnerabilitySource, DependencyReport> entry : sortedReports) {
+                            VulnerabilitySource source = entry.getKey();
+                            DependencyReport report = entry.getValue();
+                            if (report.getIssues() != null && !report.getIssues().isEmpty()) {
+                                int total = report.getIssues().size();
+                                int critical = 0, high = 0, medium = 0, low = 0, unknown = 0;
+                                for (Issue issue : report.getIssues()) {
+                                    Severity sev = issue.getSeverity();
+                                    if (sev == null) { unknown++; continue; }
+                                    switch (sev) {
+                                        case CRITICAL: critical++; break;
+                                        case HIGH: high++; break;
+                                        case MEDIUM: medium++; break;
+                                        case LOW: low++; break;
+                                        default: unknown++; break;
+                                    }
                                 }
 
-                                int num = report.getIssues().size();
-                                messageBuilder.append("Known security vulnerabilities: ")
-                                        .append(num);
-                                tooltipBuilder.append("<p>Known security vulnerabilities: ")
-                                        .append(num)
+                                String sourceLabel = source.getProvider() + "(" + source.getSource() + ")";
+                                String counts = total + " (" + critical + "/" + high + "/" + medium + "/" + low + "/" + unknown + ")";
+
+                                messageBuilder.append(System.lineSeparator())
+                                        .append("- ").append(sourceLabel).append(": ").append(counts);
+                                tooltipBuilder.append("<p>- ")
+                                        .append(escapeHtml(sourceLabel)).append(": ").append(counts)
                                         .append("</p>");
 
-                                if (report.getHighestVulnerability() != null && report.getHighestVulnerability().getSeverity() != null) {
-                                    String severity = report.getHighestVulnerability().getSeverity().getValue();
-                                    messageBuilder.append(", Highest severity: ")
-                                            .append(severity);
-                                    tooltipBuilder.append("<p>Highest severity: ")
-                                            .append(escapeHtml(severity))
-                                            .append("</p>");
+                                if (!hasFixOptions && CAIntentionAction.isQuickFixAvailable(report)) {
+                                    hasFixOptions = true;
                                 }
                             }
 
@@ -220,7 +234,14 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                                 // Fallback: use DependencyReport.recommendation only when provider-level is absent
                                 quickfixes.put(source, report);
                             }
-                        });
+                        }
+
+                        if (hasFixOptions) {
+                            messageBuilder.append(System.lineSeparator()).append(System.lineSeparator())
+                                    .append("Fixes available. Select \"More actions\" to see the options");
+                            tooltipBuilder.append("<p/>")
+                                    .append("<p>Fixes available. Select &quot;More actions&quot; to see the options</p>");
+                        }
                     }
 
                     // Add provider-level recommendation info to annotation
@@ -283,6 +304,61 @@ public abstract class CAAnnotator extends ExternalAnnotator<CAAnnotator.Info, CA
                                         }
                                     }
                                 });
+
+                                // Add advisory-based quickfixes sorted by Red Hat source first
+                                if (hasReports) {
+                                    Set<String> seenVersions = new HashSet<>();
+                                    // Exclude TC remediation versions from advisory options
+                                    quickfixes.values().stream()
+                                            .filter(r -> !CAIntentionAction.thereAreNoIssues(r))
+                                            .flatMap(r -> r.getIssues().stream())
+                                            .filter(issue -> issue.getRemediation() != null
+                                                    && issue.getRemediation().getTrustedContent() != null
+                                                    && issue.getRemediation().getTrustedContent().getRef() != null)
+                                            .forEach(issue -> {
+                                                String v = issue.getRemediation().getTrustedContent().getRef().version();
+                                                if (v != null) seenVersions.add(v);
+                                            });
+
+                                    List<Map.Entry<VulnerabilitySource, DependencyReport>> sortedForFixes = new ArrayList<>(reports.entrySet());
+                                    sortedForFixes.sort(Comparator.comparingInt(entry ->
+                                            CAIntentionAction.isRedHatSource(entry.getKey().getSource()) ? 0 : 1));
+
+                                    for (Map.Entry<VulnerabilitySource, DependencyReport> entry : sortedForFixes) {
+                                        VulnerabilitySource src = entry.getKey();
+                                        DependencyReport rpt = entry.getValue();
+                                        if (rpt.getIssues() == null) continue;
+
+                                        for (Issue issue : rpt.getIssues()) {
+                                            if (issue.getRemediation() == null) continue;
+
+                                            // Advisory-level fixedIn versions
+                                            if (issue.getRemediation().getAdvisories() != null) {
+                                                for (AdvisoryRemediation ar : issue.getRemediation().getAdvisories()) {
+                                                    if (ar.getFixedIn() != null && !ar.getFixedIn().trim().isEmpty()
+                                                            && seenVersions.add(ar.getFixedIn())) {
+                                                        String label = ar.getAdvisory() != null ? ar.getAdvisory().getId() : src.getSource();
+                                                        CAIntentionAction advisoryAction = this.createQuickFix(e, src, rpt);
+                                                        advisoryAction.setAdvisoryData(label, ar.getFixedIn());
+                                                        builder.withFix(advisoryAction);
+                                                    }
+                                                }
+                                            }
+
+                                            // Top-level fixedIn versions
+                                            if (issue.getRemediation().getFixedIn() != null) {
+                                                for (String fixedIn : issue.getRemediation().getFixedIn()) {
+                                                    if (fixedIn != null && !fixedIn.trim().isEmpty()
+                                                            && seenVersions.add(fixedIn)) {
+                                                        CAIntentionAction fixAction = this.createQuickFix(e, src, rpt);
+                                                        fixAction.setAdvisoryData(src.getSource(), fixedIn);
+                                                        builder.withFix(fixAction);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
 
                                 // Add provider-level recommendation quickfixes (one per recommendation source)
                                 if (hasRecommendations) {

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAIntentionAction.java
@@ -37,6 +37,8 @@ public abstract class CAIntentionAction implements IntentionAction {
     protected @SafeFieldForPreview DependencyReport report;
     protected @SafeFieldForPreview String recommendationSourceName;
     protected @SafeFieldForPreview RecommendationReport recommendationReport;
+    protected @SafeFieldForPreview String advisoryLabel;
+    protected @SafeFieldForPreview String advisoryFixedIn;
 
     protected CAIntentionAction(PsiElement element, VulnerabilitySource source, DependencyReport report) {
         this.element = element;
@@ -50,8 +52,17 @@ public abstract class CAIntentionAction implements IntentionAction {
         this.recommendationReport = recReport;
     }
 
+    /** Sets advisory-based fix data for vendor-specific quick-fixes. */
+    void setAdvisoryData(String label, String fixedInVersion) {
+        this.advisoryLabel = label;
+        this.advisoryFixedIn = fixedInVersion;
+    }
+
     @Override
     public @IntentionName @NotNull String getText() {
+        if (advisoryLabel != null && advisoryFixedIn != null) {
+            return "Switch to version " + advisoryFixedIn + " (" + advisoryLabel + ")";
+        }
         if (recommendationSourceName != null) {
             return getQuickFixTextForRecommendation(recommendationSourceName);
         }
@@ -66,7 +77,9 @@ public abstract class CAIntentionAction implements IntentionAction {
     @Override
     public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
         String recommendedVersion;
-        if (recommendationReport != null && recommendationReport.getRecommendation() != null) {
+        if (advisoryFixedIn != null) {
+            recommendedVersion = advisoryFixedIn;
+        } else if (recommendationReport != null && recommendationReport.getRecommendation() != null) {
             recommendedVersion = recommendationReport.getRecommendation().version();
         } else {
             recommendedVersion = getRecommendedVersion(this.report);
@@ -111,8 +124,13 @@ public abstract class CAIntentionAction implements IntentionAction {
     @Override
     public @Nullable FileModifier getFileModifierForPreview(@NotNull PsiFile target) {
         FileModifier modifier = this.createCAIntentionActionInCopy(PsiTreeUtil.findSameElementInCopy(this.element, target));
-        if (modifier instanceof CAIntentionAction copy && this.recommendationSourceName != null) {
-            copy.setRecommendationData(this.recommendationSourceName, this.recommendationReport);
+        if (modifier instanceof CAIntentionAction copy) {
+            if (this.recommendationSourceName != null) {
+                copy.setRecommendationData(this.recommendationSourceName, this.recommendationReport);
+            }
+            if (this.advisoryLabel != null) {
+                copy.setAdvisoryData(this.advisoryLabel, this.advisoryFixedIn);
+            }
         }
         return modifier;
     }
@@ -189,26 +207,36 @@ public abstract class CAIntentionAction implements IntentionAction {
     }
 
     static boolean isQuickFixAvailable(DependencyReport dependency) {
-        boolean result=false;
-        if(thereAreNoIssues(dependency))
-        {
-            if(thereIsRecommendation(dependency))
-            {
-                result = true;
-            }
+        if (thereAreNoIssues(dependency)) {
+            return thereIsRecommendation(dependency);
         }
-        else
-        {
-            if(thereIsTcRemediation(dependency))
-            {
-                result = true;
-            }
-        }
-     return result;
+        return thereIsTcRemediation(dependency) || hasAdvisoryFixes(dependency);
     }
 
     /** Checks if a provider-level recommendation report has an available quick-fix. */
     static boolean isQuickFixAvailable(RecommendationReport recReport) {
         return thereIsRecommendation(recReport);
+    }
+
+    /** Checks if a dependency has advisory-based fix versions. */
+    static boolean hasAdvisoryFixes(DependencyReport dependency) {
+        if (thereAreNoIssues(dependency)) return false;
+        return dependency.getIssues().stream()
+                .filter(issue -> issue.getRemediation() != null && issue.getRemediation().getAdvisories() != null)
+                .flatMap(issue -> issue.getRemediation().getAdvisories().stream())
+                .anyMatch(ar -> ar.getFixedIn() != null && !ar.getFixedIn().trim().isEmpty());
+    }
+
+    /** Checks whether the source identifier indicates a Red Hat or RHLW source. */
+    static boolean isRedHatSource(String sourceId) {
+        if (sourceId == null) return false;
+        String s = sourceId.toLowerCase();
+        return s.contains("redhat") || s.contains("rhlw");
+    }
+
+    /** Checks whether the source identifier indicates an RHLW (Red Hat Lightwell) source. */
+    static boolean isRhlwSource(String sourceId) {
+        if (sourceId == null) return false;
+        return sourceId.toLowerCase().contains("rhlw");
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/CAUpdateManifestIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/CAUpdateManifestIntentionAction.java
@@ -37,6 +37,21 @@ public abstract class CAUpdateManifestIntentionAction implements IntentionAction
         return getRepositoryUrlFromPurl(dependency);
     }
 
+    /** Checks if a repository URL belongs to a Red Hat Lightwell repository. */
+    protected static boolean isRhlwRepository(String repositoryUrl) {
+        return repositoryUrl != null && repositoryUrl.contains("rhlw");
+    }
+
+    /** Returns the repository display name based on the URL. */
+    protected static String getRepositoryDisplayName(String repositoryUrl) {
+        return isRhlwRepository(repositoryUrl) ? "Red Hat Lightwell Maven Repository" : "Red Hat GA Maven Repository";
+    }
+
+    /** Returns the repository ID based on the URL. */
+    protected static String getRepositoryId(String repositoryUrl) {
+        return isRhlwRepository(repositoryUrl) ? "rhlw" : "redhat-ga";
+    }
+
     /** Extracts the repository URL from a provider-level recommendation report. */
     protected static String getRepositoryUrl(RecommendationReport recReport) {
         if (recReport != null && recReport.getRecommendation() != null
@@ -53,10 +68,19 @@ public abstract class CAUpdateManifestIntentionAction implements IntentionAction
         {
             packageRef.set(dependency.getRecommendation());
         }
-        else {
-            dependency.getIssues().stream().filter(issue -> Objects.nonNull(issue.getRemediation().getTrustedContent())).findFirst().ifPresent( value -> packageRef.set(value.getRemediation().getTrustedContent().getRef()));
+        else if (dependency.getIssues() != null) {
+            dependency.getIssues().stream()
+                    .filter(issue -> issue.getRemediation() != null
+                            && issue.getRemediation().getTrustedContent() != null
+                            && issue.getRemediation().getTrustedContent().getRef() != null)
+                    .findFirst()
+                    .ifPresent(value -> packageRef.set(value.getRemediation().getTrustedContent().getRef()));
         }
-        return packageRef.get().purl().getQualifiers().get("repository_url");
+        PackageRef ref = packageRef.get();
+        if (ref == null || ref.purl() == null || ref.purl().getQualifiers() == null) {
+            return null;
+        }
+        return ref.purl().getQualifiers().get("repository_url");
     }
 
     protected CAUpdateManifestIntentionAction(PsiElement element, DependencyReport dependency) {

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/gradle/GradleCAUpdateManifestIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/gradle/GradleCAUpdateManifestIntentionAction.java
@@ -19,7 +19,8 @@ import java.util.Arrays;
 public class GradleCAUpdateManifestIntentionAction extends CAUpdateManifestIntentionAction {
     @Override
     protected String getTextImpl() {
-        return "Add Redhat GA Maven Repository to your build.gradle";
+        String repoUrl = getRepositoryUrl(this.dependency);
+        return "Add " + getRepositoryDisplayName(repoUrl) + " to your build.gradle";
     }
 
     public GradleCAUpdateManifestIntentionAction(PsiElement element, DependencyReport report) {
@@ -63,8 +64,11 @@ public class GradleCAUpdateManifestIntentionAction extends CAUpdateManifestInten
         if (repositoriesFromBuildGradle == null) {
             return false;
         }
-        final String mavenRhGa = "https://maven.repository.redhat.com/ga/";
-        String mavenGaRepo = formatArtifactsRepository(mavenRhGa);
-        return !(repositoriesFromBuildGradle.getText().contains(mavenGaRepo) || repositoriesFromBuildGradle.getText().contains(mavenRhGa));
+        String repoUrl = getRepositoryUrl(this.dependency);
+        if (repoUrl == null) {
+            return false;
+        }
+        String mavenRepo = formatArtifactsRepository(repoUrl);
+        return !(repositoriesFromBuildGradle.getText().contains(mavenRepo) || repositoriesFromBuildGradle.getText().contains(repoUrl));
     }
 }

--- a/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAUpdateManifestIntentionAction.java
+++ b/src/main/java/org/jboss/tools/intellij/componentanalysis/maven/MavenCAUpdateManifestIntentionAction.java
@@ -18,7 +18,8 @@ import java.util.Optional;
 public final class MavenCAUpdateManifestIntentionAction extends CAUpdateManifestIntentionAction {
     @Override
     protected String getTextImpl() {
-        return "Add Redhat GA Maven Repository to your pom.xml";
+        String repoUrl = getRepositoryUrl(this.dependency);
+        return "Add " + getRepositoryDisplayName(repoUrl) + " to your pom.xml";
     }
 
     MavenCAUpdateManifestIntentionAction(PsiElement element, DependencyReport report) {
@@ -46,15 +47,19 @@ public final class MavenCAUpdateManifestIntentionAction extends CAUpdateManifest
         XmlTag repository = repositories.createChildTag("repository", repositories.getNamespace(), "", false);
         repository.setName("repository");
 
-        XmlTag id = repository.createChildTag("id", repository.getNamespace(), "redhat-ga", false);
-        XmlTag name = repository.createChildTag("name", repository.getNamespace(), "Redhat GA Maven Repository", false);
-        XmlTag url = repository.createChildTag("url", repository.getNamespace(), getRepositoryUrl(dependency), false);
+        String repoUrl = getRepositoryUrl(dependency);
+        String repoId = getRepositoryId(repoUrl);
+        String repoName = getRepositoryDisplayName(repoUrl);
+
+        XmlTag id = repository.createChildTag("id", repository.getNamespace(), repoId, false);
+        XmlTag name = repository.createChildTag("name", repository.getNamespace(), repoName, false);
+        XmlTag url = repository.createChildTag("url", repository.getNamespace(), repoUrl, false);
         id.setName("id");
         name.setName("name");
         url.setName("url");
-        id.getValue().setText("redhat-ga");
-        name.getValue().setText("Redhat GA Maven Repository");
-        url.getValue().setText(getRepositoryUrl(dependency));
+        id.getValue().setText(repoId);
+        name.getValue().setText(repoName);
+        url.getValue().setText(repoUrl);
         repository.addSubTag(id,false);
         repository.addSubTag(name,false);
         repository.addSubTag(url,false);
@@ -82,11 +87,12 @@ public final class MavenCAUpdateManifestIntentionAction extends CAUpdateManifest
         Optional<PsiElement> repoWrapper = Arrays.stream(rootPomElement.getChildren()).filter(psi -> psi instanceof XmlTag && ((XmlTag) psi).getName().equals("repositories")).findFirst();
         if (repoWrapper.isPresent()) {
              XmlTag repositories = (XmlTag) repoWrapper.get();
+            String targetRepoId = getRepositoryId(getRepositoryUrl(this.dependency));
             repositoryInPom = Arrays.stream(repositories.getChildren())
                     .flatMap(element -> Arrays.stream(element.getChildren()))
                     .filter(element -> element instanceof XmlTag && "id".equals(((XmlTag) element).getName()))
                     .flatMap(tagValue -> Arrays.stream(((XmlTag) tagValue).getValue().getChildren()))
-                    .anyMatch(tag -> tag instanceof XmlText && (((XmlText) tag).getValue().trim().equals("redhat-ga")));
+                    .anyMatch(tag -> tag instanceof XmlText && (((XmlText) tag).getValue().trim().equals(targetRepoId)));
 
         }
 


### PR DESCRIPTION
## Summary

- Extract fix versions from both `advisories[].fixedIn` and top-level `remediation.fixedIn[]`, surfacing them as multiple intention action quick-fix options per vulnerable dependency
- Sort Red Hat and RHLW sources first in annotations and quick-fixes using `sourceId`-based detection (`isRedHatSource`)
- Adapt Maven/Gradle repository manifest actions to show Red Hat Lightwell repository for RHLW-sourced recommendations via `isRhlwRepository`
- Show compact per-source severity breakdown in hover tooltip matching VS Code format: `provider(source): TOTAL (C/H/M/L/U)`
- Show advisory IDs with fix versions in intention action labels: `Switch to version X (ADVISORY-ID)`
- Bump `trustify-da-api-model` from 2.0.9 to 2.0.12
- Fix NPE in `getRepositoryUrlFromPurl` when no TC remediation or recommendation exists
- Preserve existing trustedContent quick-fix behavior

Implements [TC-5023](https://redhat.atlassian.net/browse/TC-5023)

## Test plan

- [ ] Open a pom.xml with vulnerable dependencies (e.g., `spring-boot:2.7.18`)
- [ ] Verify compact severity breakdown appears in hover tooltip: `rhtpa(rhlw-remediated): 2 (0/1/0/0/1)`
- [ ] Verify Red Hat / RHLW sourced sources appear before community sources in tooltip
- [ ] Verify "Fixes available. Select 'More actions' to see the options" message appears
- [ ] Click "More actions..." — verify multiple fix version intention actions appear
- [ ] Verify advisory-based fixes show as "Switch to version X (ADVISORY-ID)"
- [ ] Accept an RHLW-sourced fix on pom.xml — verify Lightwell repository is added
- [ ] Accept a Red Hat GA-sourced fix on pom.xml — verify GA repository is added
- [ ] Verify existing trustedContent quick-fix still works as the primary intention action
- [ ] Verify recommendation-only dependencies (no vulnerabilities) are unaffected
- [ ] Repeat with build.gradle for Gradle repository manifest adaptation

🤖 Generated with [Claude Code](https://claude.com/claude-code)